### PR TITLE
Fixed TypeError being thrown for missing HOME env var on Windows.

### DIFF
--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -105,7 +105,13 @@ from collections import defaultdict, namedtuple
 
 # Where to store downloaded test sets.
 # Define the environment variable $SACREBLEU, or use the default of ~/.sacrebleu.
-SACREBLEU = os.environ.get('SACREBLEU', os.path.join(os.environ.get('HOME'), '.sacrebleu'))
+#
+# Querying for a HOME environment variable can result in None (e.g., on Windows)
+# in which case the os.path.join() throws a TypeError. Using expanduser() is
+# a safe way to get the user's home folder.
+from os.path import expanduser
+USERHOME = expanduser("~")
+SACREBLEU = os.environ.get('SACREBLEU', os.path.join(USERHOME, '.sacrebleu'))
 
 # This defines data locations.
 # At the top level are test sets.

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -467,10 +467,10 @@ tokenizers = {
 }
 
 
-def _read(file):
+def _read(file, encoding):
     if file.endswith('.gz'):
-        return gzip.open(file, 'rt')
-    return open(file, 'rt')
+        return gzip.open(file, 'rt', encoding=encoding)
+    return open(file, 'rt', encoding=encoding)
 
 
 def my_log(num):
@@ -739,6 +739,8 @@ def main():
                             help='Insist that your tokenized input is actually detokenized.')
     arg_parser.add_argument('--quiet', '-q', default=False, action='store_true',
                             help='Suppress informative output.')
+    arg_parser.add_argument('--encoding', '-e', type=str, default='utf-8',
+                            help='Open text files with specified encoding')
     args = arg_parser.parse_args()
 
     if not args.quiet:
@@ -783,7 +785,7 @@ def main():
         refs = args.refs
 
     # Read references
-    refs = [_read(x) for x in refs]
+    refs = [_read(x, args.encoding) for x in refs]
 
     if args.langpair is not None:
         source, target = args.langpair.split('-')


### PR DESCRIPTION
Running sacreBLEU.py on Windows fails as there is no HOME environment variable set.

PS C:\Users\chrife\Documents\GitHub\sacreBLEU> C:\Python34\python.exe .\sacrebleu.py
Traceback (most recent call last):
  File ".\sacrebleu.py", line 108, in <module>
    SACREBLEU = os.environ.get('SACREBLEU', os.path.join(os.environ.get('HOME'), '.sacrebleu'))
  File "C:\Python34\lib\ntpath.py", line 108, in join
    result_drive, result_path = splitdrive(path)
  File "C:\Python34\lib\ntpath.py", line 159, in splitdrive
    if len(p) > 1:
TypeError: object of type 'NoneType' has no len()

Using expanduser() fixes this.