### PR TITLE
Fix closest_len = len issue.

### DIFF
--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -551,7 +551,7 @@ def ref_stats(output, refs):
             closest_len = reflen
         elif diff == closest_diff:
             if reflen < closest_len:
-                closest_len = len
+                closest_len = reflen
 
         ngrams_ref = extract_ngrams(ref)
         for ngram in ngrams_ref.keys():


### PR DESCRIPTION
Running the current sacrebleu.py with multiple references results in a `TypeError` as you are not adding an `int` value but a `builtin`.

    Traceback (most recent call last):
      File ".\sacrebleu.py", line 798, in <module>
        main()
      File ".\sacrebleu.py", line 790, in main
        lc=args.lc, tokenize=args.tokenize)
      File ".\sacrebleu.py", line 684, in compute_bleu
        ref_len += closest_len
    TypeError: unsupported operand type(s) for +=: 'int' and 'builtin_function_or_method'
