### PR TITLE
Fix minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Download the source for one of the pre-defined test sets:
 
 (you can also use long parameter names for readability):
 
-    sacrebleu --test-set wmt14 --langpair de-en --echo src > wmt14-de-en.src
+    sacrebleu --test-set wmt14 --language-pair de-en --echo src > wmt14-de-en.src
 
 After tokenizing, translating, and detokenizing it, you can score your decoder output easily:
 

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -565,7 +565,7 @@ def tokenize_13a(line):
 class UnicodeRegex:
     """Ad-hoc hack to recognize all punctuation and symbols.
 
-    without dependening on https://pypi.python.org/pypi/regex/."""
+    without depending on https://pypi.python.org/pypi/regex/."""
     def _property_chars(prefix):
         return ''.join(chr(x) for x in range(sys.maxunicode)
                        if unicodedata.category(chr(x)).startswith(prefix))


### PR DESCRIPTION
Extremely dumb little change: fix minor typo in the instructions. Change langpair argument to language-pair.