### PR TITLE
Control characters are treated as normal characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # VERSION HISTORY
 
+- 1.2.21 (19 March 2019)
+   - Ctrl-M characters are now treated as normal characters, previously treated as newline.
+
 - 1.2.20 (28 February 2018)
    - Tokenization now defaults to "zh" when language pair is known
 

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -822,8 +822,8 @@ def smart_open(file, mode='rt', encoding='utf-8'):
     :param encoding: The file encoding.
     """
     if file.endswith('.gz'):
-        return gzip.open(file, mode=mode, encoding=encoding)
-    return open(file, mode=mode, encoding=encoding)
+        return gzip.open(file, mode=mode, encoding=encoding, newline="\n")
+    return open(file, mode=mode, encoding=encoding, newline="\n")
 
 
 def my_log(num):
@@ -1402,7 +1402,7 @@ def main():
     args = arg_parser.parse_args()
 
     # Explicitly set the encoding
-    sys.stdin = open(sys.stdin.fileno(), mode='r', encoding='utf-8', buffering=True)
+    sys.stdin = open(sys.stdin.fileno(), mode='r', encoding='utf-8', buffering=True, newline="\n")
     sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf-8', buffering=True)
 
     if not args.quiet:

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -38,7 +38,7 @@ from collections import Counter, namedtuple
 from itertools import zip_longest
 from typing import List, Iterable, Tuple
 
-VERSION = '1.2.20'
+VERSION = '1.2.21'
 
 try:
     # SIGPIPE is not available on Windows machines, throwing an exception.

--- a/test.sh
+++ b/test.sh
@@ -102,5 +102,14 @@ for pair in cs-en de-en en-cs en-de en-fi en-lv en-ru en-tr en-zh fi-en lv-en ru
     done
 done
 
+score1=$( echo "Hello! How are you doing today?" | ../sacrebleu.py -w 2 -b <(echo "Hello! How are you  doing today?") )
+score2=$( echo "Hello! How are you doing today?" | ../sacrebleu.py -w 2 -b <(echo "Hello! How are you doing today?") )
+if [[ $score1 != $score2 ]]; then 
+  echo "Control character in reference test failed"
+  exit 1
+fi
+let i++
+echo "Passed control character in reference test"
+
 echo "Passed $i tests."
 exit 0


### PR DESCRIPTION
A reference file if not managed properly (imported from windows system) can trigger ctrl-M characters. A file with ctrl-M characters is read as newline in sacreBleu script. This fix will assume ctrl-M characters as spaces.

Added a test to check for the same. 