### PR TITLE
Allow evaluation on concatenation of multiple test sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This installs a shell script, `sacrebleu`.
 
 Get a list of available test sets:
 
-    sacrebleu
+    sacrebleu --list
 
 Download the source for one of the pre-defined test sets:
 
@@ -76,7 +76,7 @@ SacreBLEU is licensed under the Apache 2.0 License.
 
 This was all Rico Sennrich's idea.
 Originally written by Matt Post.
-The official version can be found at <https://github.com/awslabs/sockeye/tree/master/sockeye_contrib/sacrebleu>; the development version at <https://github.com/mjpost/sacrebleu>.
+The official version can be found at <https://github.com/mjpost/sacrebleu>.
 
 If you use SacreBLEU, please cite the following:
 

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1599,8 +1599,6 @@ def main():
 
     # concat_ref_files is a list of list of reference filenames, for example:
     # concat_ref_files = [[testset1_refA, testset1_refB], [testset2_refA, testset2_refB]]
-    # Note that concatenation is possible only for internal test sets,
-    # which do not currently support multiple references, so the example is hypothetical.
     if args.test_set is None:
         concat_ref_files = [args.refs]
     else:

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1553,11 +1553,19 @@ def main():
         logging.error('Unknown test set "%s"\n%s', args.test_set, get_a_list_of_testset_names())
         sys.exit(1)
 
-    if args.test_set and (args.langpair is None or args.langpair not in DATASETS[args.test_set]):
-        if args.langpair is None:
-            logging.error('I need a language pair (-l).')
-        elif args.langpair not in DATASETS[args.test_set]:
-            logging.error('No such language pair "%s"', args.langpair)
+    if args.test_set is None:
+        if len(args.refs) == 0:
+            logging.error('I need either a predefined test set (-t) or a list of references')
+            logging.error(get_a_list_of_testset_names())
+            sys.exit(1)
+    elif len(args.refs) > 0:
+        logging.error('I need exactly one of (a) a predefined test set (-t) or (b) a list of references')
+        sys.exit(1)
+    elif args.langpair is None:
+        logging.error('I need a language pair (-l).')
+        sys.exit(1)
+    elif args.langpair not in DATASETS[args.test_set]:
+        logging.error('No such language pair "%s"', args.langpair)
         logging.error('Available language pairs for test set "%s": %s', args.test_set,
                       ', '.join(filter(lambda x: '-' in x, DATASETS[args.test_set].keys())))
         sys.exit(1)
@@ -1568,14 +1576,6 @@ def main():
             sys.exit(1)
         print_test_set(args.test_set, args.langpair, args.echo)
         sys.exit(0)
-
-    if args.test_set is None and len(args.refs) == 0:
-        logging.error('I need either a predefined test set (-t) or a list of references')
-        logging.error(get_a_list_of_testset_names())
-        sys.exit(1)
-    elif args.test_set is not None and len(args.refs) > 0:
-        logging.error('I need exactly one of (a) a predefined test set (-t) or (b) a list of references')
-        sys.exit(1)
 
     if args.test_set is not None and args.tokenize == 'none':
         logging.warning("You are turning off sacrebleu's internal tokenization ('--tokenize none'), presumably to supply\n"

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1189,7 +1189,7 @@ def compute_bleu(correct: List[int],
                  use_effective_order = False) -> BLEU:
     """Computes BLEU score from its sufficient statistics. Adds smoothing.
 
-    Smoothing methods (citing "A Systematic Comparison of Smoothing Techniques for Sentence-Level BLEU", 
+    Smoothing methods (citing "A Systematic Comparison of Smoothing Techniques for Sentence-Level BLEU",
     Boxing Chen and Colin Cherry, WMT 2014: http://aclweb.org/anthology/W14-3346)
 
     - exp: NIST smoothing method (Method 3)
@@ -1335,8 +1335,8 @@ def corpus_bleu(sys_stream: Union[str, Iterable[str]],
     return compute_bleu(correct, total, sys_len, ref_len, smooth_method=smooth_method, smooth_value=smooth_value, use_effective_order=use_effective_order)
 
 
-def raw_corpus_bleu(sys_stream, 
-                    ref_streams, 
+def raw_corpus_bleu(sys_stream,
+                    ref_streams,
                     smooth_value=SMOOTH_VALUE_DEFAULT) -> BLEU:
     """Convenience function that wraps corpus_bleu().
     This is convenient if you're using sacrebleu as a library, say for scoring on dev.
@@ -1453,9 +1453,10 @@ def sentence_chrf(hypothesis: str,
 
 
 def main():
-    arg_parser = argparse.ArgumentParser(description='sacreBLEU: Hassle-free computation of shareable BLEU scores.'
-                                         'Quick usage: score your detokenized output against WMT\'14 EN-DE:'
-                                         '    cat output.detok.de | ./sacreBLEU -t wmt14 -l en-de')
+    arg_parser = argparse.ArgumentParser(description='sacreBLEU: Hassle-free computation of shareable BLEU scores.\n'
+                                         'Quick usage: score your detokenized output against WMT\'14 EN-DE:\n'
+                                         '    cat output.detok.de | sacrebleu -t wmt14 -l en-de',
+                                         formatter_class=argparse.RawDescriptionHelpFormatter)
     arg_parser.add_argument('--test-set', '-t', type=str, default=None,
                             choices=DATASETS.keys(),
                             help='the test set to use')

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -121,6 +121,7 @@ DATASETS = {
     },
     'wmt19': {
         'data': ['http://data.statmt.org/wmt19/translation-task/test.tgz'],
+        'description': 'Official evaluation data.',
         'md5': ['84de7162d158e28403103b01aeefc39a'],
         'cs-de': ['sgm/newstest2019-csde-src.cs.sgm', 'sgm/newstest2019-csde-ref.de.sgm'],
         'de-cs': ['sgm/newstest2019-decs-src.de.sgm', 'sgm/newstest2019-decs-ref.cs.sgm'],
@@ -1452,6 +1453,14 @@ def sentence_chrf(hypothesis: str,
     return _chrf(avg_precision, avg_recall, beta=beta)
 
 
+def get_a_list_of_testset_names():
+    """Return a string with a formatted list of available test sets plus their descriptions. """
+    message = 'The available test sets are:'
+    for testset in sorted(DATASETS.keys(), reverse=True):
+        message += '\n%20s: %s' % (testset, DATASETS[testset].get('description', ''))
+    return message
+
+
 def main():
     arg_parser = argparse.ArgumentParser(description='sacreBLEU: Hassle-free computation of shareable BLEU scores.\n'
                                          'Quick usage: score your detokenized output against WMT\'14 EN-DE:\n'
@@ -1535,9 +1544,7 @@ def main():
         sys.exit(1)
 
     if args.test_set is not None and args.test_set not in DATASETS:
-        logging.error('The available test sets are: ')
-        for testset in sorted(DATASETS.keys(), reverse=True):
-            logging.error('  %s: %s', testset, DATASETS[testset].get('description', ''))
+        logging.error('Unknown test set "%s"\n%s', args.test_set, get_a_list_of_testset_names())
         sys.exit(1)
 
     if args.test_set and (args.langpair is None or args.langpair not in DATASETS[args.test_set]):
@@ -1558,9 +1565,7 @@ def main():
 
     if args.test_set is None and len(args.refs) == 0:
         logging.error('I need either a predefined test set (-t) or a list of references')
-        logging.error('The available test sets are: ')
-        for testset in sorted(DATASETS.keys(), reverse=True):
-            logging.error('  %s: %s', testset, DATASETS[testset].get('description', ''))
+        logging.error(get_a_list_of_testset_names())
         sys.exit(1)
     elif args.test_set is not None and len(args.refs) > 0:
         logging.error('I need exactly one of (a) a predefined test set (-t) or (b) a list of references')

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1465,10 +1465,10 @@ def main():
     arg_parser = argparse.ArgumentParser(description='sacreBLEU: Hassle-free computation of shareable BLEU scores.\n'
                                          'Quick usage: score your detokenized output against WMT\'14 EN-DE:\n'
                                          '    cat output.detok.de | sacrebleu -t wmt14 -l en-de',
+                                         #epilog = 'Available test sets: ' + ','.join(sorted(DATASETS.keys(), reverse=True)),
                                          formatter_class=argparse.RawDescriptionHelpFormatter)
     arg_parser.add_argument('--test-set', '-t', type=str, default=None,
-                            choices=DATASETS.keys(),
-                            help='the test set to use')
+                            help='the test set to use (see also --list)')
     arg_parser.add_argument('-lc', action='store_true', default=False,
                             help='use case-insensitive BLEU (default: actual case)')
     arg_parser.add_argument('--smooth', '-s', choices=['exp', 'floor', 'add-n', 'none'], default='exp',
@@ -1507,6 +1507,8 @@ def main():
                             help='suppress informative output')
     arg_parser.add_argument('--encoding', '-e', type=str, default='utf-8',
                             help='open text files with specified encoding (default: %(default)s)')
+    arg_parser.add_argument('--list', default=False, action='store_true',
+                            help='print a list of all available test sets.')
     arg_parser.add_argument('--citation', '--cite', default=False, action='store_true',
                             help='dump the bibtex citation and quit.')
     arg_parser.add_argument('--width', '-w', type=int, default=1,
@@ -1524,6 +1526,10 @@ def main():
 
     if args.download:
         download_test_set(args.download, args.langpair)
+        sys.exit(0)
+
+    if args.list:
+        print(get_a_list_of_testset_names())
         sys.exit(0)
 
     if args.citation:

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1468,7 +1468,7 @@ def main():
                                          #epilog = 'Available test sets: ' + ','.join(sorted(DATASETS.keys(), reverse=True)),
                                          formatter_class=argparse.RawDescriptionHelpFormatter)
     arg_parser.add_argument('--test-set', '-t', type=str, default=None,
-                            help='the test set to use (see also --list)')
+                            help='the test set to use (see also --list) or a comma-separated list of test sets to be concatenated')
     arg_parser.add_argument('-lc', action='store_true', default=False,
                             help='use case-insensitive BLEU (default: actual case)')
     arg_parser.add_argument('--smooth', '-s', choices=['exp', 'floor', 'add-n', 'none'], default='exp',
@@ -1536,11 +1536,11 @@ def main():
         if not args.test_set:
             logging.error('I need a test set (-t).')
             sys.exit(1)
-        elif 'citation' not in DATASETS[args.test_set]:
-            logging.error('No citation found for %s', args.test_set)
-            sys.exit(1)
-
-        print(DATASETS[args.test_set]['citation'])
+        for test_set in args.test_set.split(','):
+            if 'citation' not in DATASETS[test_set]:
+                logging.error('No citation found for %s', test_set)
+            else:
+                print(DATASETS[test_set]['citation'])
         sys.exit(0)
 
     if args.num_refs != 1 and (args.test_set is not None or len(args.refs) > 1):
@@ -1549,9 +1549,11 @@ def main():
         logging.error('and you cannot then provide multiple reference files.')
         sys.exit(1)
 
-    if args.test_set is not None and args.test_set not in DATASETS:
-        logging.error('Unknown test set "%s"\n%s', args.test_set, get_a_list_of_testset_names())
-        sys.exit(1)
+    if args.test_set is not None:
+        for test_set in args.test_set.split(','):
+            if test_set not in DATASETS:
+                logging.error('Unknown test set "%s"\n%s', test_set, get_a_list_of_testset_names())
+                sys.exit(1)
 
     if args.test_set is None:
         if len(args.refs) == 0:
@@ -1564,17 +1566,20 @@ def main():
     elif args.langpair is None:
         logging.error('I need a language pair (-l).')
         sys.exit(1)
-    elif args.langpair not in DATASETS[args.test_set]:
-        logging.error('No such language pair "%s"', args.langpair)
-        logging.error('Available language pairs for test set "%s": %s', args.test_set,
-                      ', '.join(filter(lambda x: '-' in x, DATASETS[args.test_set].keys())))
-        sys.exit(1)
+    else:
+        for test_set in args.test_set.split(','):
+            if args.langpair not in DATASETS[test_set]:
+                logging.error('No such language pair "%s"', args.langpair)
+                logging.error('Available language pairs for test set "%s": %s', test_set,
+                      ', '.join(x for x in DATASETS[test_set].keys() if '-' in x))
+                sys.exit(1)
 
     if args.echo:
         if args.langpair is None or args.test_set is None:
             logging.warning("--echo requires a test set (--t) and a language pair (-l)")
             sys.exit(1)
-        print_test_set(args.test_set, args.langpair, args.echo)
+        for test_set in args.test_set.split(','):
+            print_test_set(test_set, args.langpair, args.echo)
         sys.exit(0)
 
     if args.test_set is not None and args.tokenize == 'none':
@@ -1592,30 +1597,38 @@ def main():
     if args.langpair is not None and args.langpair.split('-')[1] == 'zh' and 'bleu' in args.metrics and args.tokenize != 'zh':
         logging.warning('You should also pass "--tok zh" when scoring Chinese...')
 
-    if args.test_set:
-        _, *ref_files = download_test_set(args.test_set, args.langpair)
-        if len(ref_files) == 0:
-            print('No references found for test set {}/{}.'.format(args.test_set, args.langpair))
-            sys.exit(1)
+    # concat_ref_files is a list of list of reference filenames, for example:
+    # concat_ref_files = [[testset1_refA, testset1_refB], [testset2_refA, testset2_refB]]
+    # Note that concatenation is possible only for internal test sets,
+    # which do not currently support multiple references, so the example is hypothetical.
+    if args.test_set is None:
+        concat_ref_files = [args.refs]
     else:
-        ref_files = args.refs
+        concat_ref_files = []
+        for test_set in args.test_set.split(','):
+            _, *ref_files = download_test_set(test_set, args.langpair)
+            if len(ref_files) == 0:
+                logging.warning('No references found for test set {}/{}.'.format(test_set, args.langpair))
+            concat_ref_files.append(ref_files)
+
 
     inputfh = io.TextIOWrapper(sys.stdin.buffer, encoding=args.encoding) if args.input == '-' else smart_open(args.input, encoding=args.encoding)
     system = inputfh.readlines()
 
     # Read references
-    refs = [[] for x in range(max(len(ref_files), args.num_refs))]
-    for refno, ref_file in enumerate(ref_files):
-        for lineno, line in enumerate(smart_open(ref_file, encoding=args.encoding), 1):
-            if args.num_refs != 1:
-                splits = line.rstrip().split(sep='\t', maxsplit=args.num_refs-1)
-                if len(splits) != args.num_refs:
-                    logging.error('FATAL: line {}: expected {} fields, but found {}.'.format(lineno, args.num_refs, len(splits)))
-                    sys.exit(17)
-                for refno, split in enumerate(splits):
-                    refs[refno].append(split)
-            else:
-                refs[refno].append(line)
+    refs = [[] for x in range(max(len(concat_ref_files[0]), args.num_refs))]
+    for ref_files in concat_ref_files:
+        for refno, ref_file in enumerate(ref_files):
+            for lineno, line in enumerate(smart_open(ref_file, encoding=args.encoding), 1):
+                if args.num_refs != 1:
+                    splits = line.rstrip().split(sep='\t', maxsplit=args.num_refs-1)
+                    if len(splits) != args.num_refs:
+                        logging.error('FATAL: line {}: expected {} fields, but found {}.'.format(lineno, args.num_refs, len(splits)))
+                        sys.exit(17)
+                        for refno, split in enumerate(splits):
+                            refs[refno].append(split)
+                else:
+                    refs[refno].append(line)
 
     try:
         if 'bleu' in args.metrics:

--- a/test.sh
+++ b/test.sh
@@ -36,6 +36,14 @@ limit_test=${1:-}
 [[ -d $SACREBLEU/wmt17 ]] && rm -f $SACREBLEU/wmt17/{en-*,*-en*}
 ./sacrebleu.py --echo src -t wmt17 -l cs-en > /dev/null
 
+# Test concatenation of multiple test sets, --echo, -w and a pipeline with two sacrebleu processes
+expected=53.7432
+obtained=`./sacrebleu.py -t wmt16,wmt17 -l en-fi --echo ref | ./sacrebleu.py -b -w 4 -t wmt16/B,wmt17/B -l en-fi`
+if [[ $obtained != $expected ]]; then
+    echo -e "Concat test-set test failed:\n expected = $expected\n obtained = $obtained"
+    exit 1
+fi
+
 # Test loading via file instead of STDIN
 ./sacrebleu.py -t wmt17 -l en-de --echo ref > .wmt17.en-de.de.tmp
 score=$(./sacrebleu.py -t wmt17 -l en-de -i .wmt17.en-de.de.tmp -b)


### PR DESCRIPTION
This PR is just about the last commit (2c0e788), the previous commits are part of https://github.com/mjpost/sacreBLEU/pull/41 (and should be discussed there).

I used bash for the test to keep consistency with the existing test.sh and also because I can test few other things (e.g. #31) more easily than with pytest.
I think @cfedermann is considering to rewrite all the tests into Python.