### PR TITLE
chrF signature should not include the tokenization variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # VERSION HISTORY
 
+- 1.4.2 (not released yet)
+  - Tokenization variant omitted from the chrF signature (it is relevant only for BLEU).
+
 - 1.4.1 (2019-09-11)
    - Added sentence-level scoring via -sl (--sentence-level)
 

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -998,8 +998,7 @@ def chrf_signature(args, numrefs):
         'subset': 'S',
     }
 
-    signature = {'tok': args.tokenize,
-                 'version': VERSION,
+    signature = {'version': VERSION,
                  'space': args.chrf_whitespace,
                  'numchars': args.chrf_order,
                  'numrefs': numrefs,


### PR DESCRIPTION
Tokenization is used only for BLEU, not for chrF.
Including `tok.13a` in the chrF signature is thus misleading.
Also, this commit fixes a bug causing `KeyError: 'tok'` when trying to use `-m chrf --short`.