### PR TITLE
Fixed bug in add-k smoothing

### DIFF
--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1609,7 +1609,7 @@ def main():
                             help='Use case-insensitive BLEU (default: actual case)')
     arg_parser.add_argument('--sentence-level', '-sl', action='store_true',
                             help='Output metric on each sentence.')
-    arg_parser.add_argument('--smooth', '-s', choices=['exp', 'floor', 'add-n', 'none'], default='exp',
+    arg_parser.add_argument('--smooth', '-s', choices=['exp', 'floor', 'add-k', 'none'], default='exp',
                             help='smoothing method: exponential decay (default), floor (increment zero counts), add-k (increment num/denom by k for n>1), or none')
     arg_parser.add_argument('--smooth-value', '-sv', type=float, default=SMOOTH_VALUE_DEFAULT,
                             help='The value to pass to the smoothing technique, when relevant. Default: %(default)s.')

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1296,7 +1296,7 @@ def compute_bleu(correct: List[int],
     smooth_mteval = 1.
     effective_order = NGRAM_ORDER
     for n in range(NGRAM_ORDER):
-        if smooth_method == 'add-k' and n > 1:
+        if smooth_method == 'add-k' and n > 0:
             correct[n] += smooth_value
             total[n] += smooth_value
         if total[n] == 0:

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1295,7 +1295,7 @@ def compute_bleu(correct: List[int],
 
     smooth_mteval = 1.
     effective_order = NGRAM_ORDER
-    for n in range(1, NGRAM_ORDER):
+    for n in range(1, NGRAM_ORDER + 1):
         if smooth_method == 'add-k' and n > 1:
             correct[n-1] += 1
             total[n-1] += 1

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1730,6 +1730,9 @@ def main():
             print_test_set(test_set, args.langpair, args.echo, args.origlang, args.subset)
         sys.exit(0)
 
+    if args.smooth == 'add-k' and args.smooth_value == SMOOTH_VALUE_DEFAULT:
+        args.smooth_value = 1
+
     if args.test_set is not None and args.tokenize == 'none':
         logging.warning("You are turning off sacrebleu's internal tokenization ('--tokenize none'), presumably to supply\n"
                         "your own reference tokenization. Published numbers will not be comparable with other papers.\n")

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1295,24 +1295,24 @@ def compute_bleu(correct: List[int],
 
     smooth_mteval = 1.
     effective_order = NGRAM_ORDER
-    for n in range(NGRAM_ORDER):
-        if smooth_method == 'add-k' and n > 0:
-            correct[n] += 1
-            total[n] += 1
-        if total[n] == 0:
+    for n in range(1, NGRAM_ORDER):
+        if smooth_method == 'add-k' and n > 1:
+            correct[n-1] += 1
+            total[n-1] += 1
+        if total[n-1] == 0:
             break
 
         if use_effective_order:
-            effective_order = n + 1
+            effective_order = n
 
-        if correct[n] == 0:
+        if correct[n-1] == 0:
             if smooth_method == 'exp':
                 smooth_mteval *= 2
-                precisions[n] = 100. / (smooth_mteval * total[n])
+                precisions[n-1] = 100. / (smooth_mteval * total[n-1])
             elif smooth_method == 'floor':
-                precisions[n] = 100. * smooth_value / total[n]
+                precisions[n-1] = 100. * smooth_value / total[n-1]
         else:
-            precisions[n] = 100. * correct[n] / total[n]
+            precisions[n-1] = 100. * correct[n-1] / total[n-1]
 
     # If the system guesses no i-grams, 1 <= i <= NGRAM_ORDER, the BLEU score is 0 (technically undefined).
     # This is a problem for sentence-level BLEU or a corpus of short sentences, where systems will get no credit

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1297,8 +1297,8 @@ def compute_bleu(correct: List[int],
     effective_order = NGRAM_ORDER
     for n in range(NGRAM_ORDER):
         if smooth_method == 'add-k' and n > 0:
-            correct[n] += smooth_value
-            total[n] += smooth_value
+            correct[n] += 1
+            total[n] += 1
         if total[n] == 0:
             break
 

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1290,6 +1290,8 @@ def compute_bleu(correct: List[int],
     :param use_effective_order: If true, use the length of `correct` for the n-gram order instead of NGRAM_ORDER.
     :return: A BLEU object with the score (100-based) and other statistics.
     """
+    if smooth_method == 'add-k' and smooth_value == SMOOTH_VALUE_DEFAULT:
+        smooth_value = 1
 
     precisions = [0 for x in range(NGRAM_ORDER)]
 
@@ -1729,9 +1731,6 @@ def main():
         for test_set in args.test_set.split(','):
             print_test_set(test_set, args.langpair, args.echo, args.origlang, args.subset)
         sys.exit(0)
-
-    if args.smooth == 'add-k' and args.smooth_value == SMOOTH_VALUE_DEFAULT:
-        args.smooth_value = 1
 
     if args.test_set is not None and args.tokenize == 'none':
         logging.warning("You are turning off sacrebleu's internal tokenization ('--tokenize none'), presumably to supply\n"

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -1297,8 +1297,8 @@ def compute_bleu(correct: List[int],
     effective_order = NGRAM_ORDER
     for n in range(1, NGRAM_ORDER + 1):
         if smooth_method == 'add-k' and n > 1:
-            correct[n-1] += 1
-            total[n-1] += 1
+            correct[n-1] += smooth_value
+            total[n-1] += smooth_value
         if total[n-1] == 0:
             break
 

--- a/sacrebleu.py
+++ b/sacrebleu.py
@@ -71,7 +71,7 @@ CHRF_ORDER = 6
 CHRF_BETA = 2
 
 # The default floor value to use with `--smooth floor`
-SMOOTH_VALUE_DEFAULT = 0.0
+SMOOTH_VALUE_DEFAULT = {'floor': 0.0, 'add-k': 1}
 
 # This defines data locations.
 # At the top level are test sets.
@@ -1269,7 +1269,7 @@ def compute_bleu(correct: List[int],
                  sys_len: int,
                  ref_len: int,
                  smooth_method = 'none',
-                 smooth_value = SMOOTH_VALUE_DEFAULT,
+                 smooth_value = None,
                  use_effective_order = False) -> BLEU:
     """Computes BLEU score from its sufficient statistics. Adds smoothing.
 
@@ -1290,8 +1290,8 @@ def compute_bleu(correct: List[int],
     :param use_effective_order: If true, use the length of `correct` for the n-gram order instead of NGRAM_ORDER.
     :return: A BLEU object with the score (100-based) and other statistics.
     """
-    if smooth_method == 'add-k' and smooth_value == SMOOTH_VALUE_DEFAULT:
-        smooth_value = 1
+    if smooth_method in SMOOTH_VALUE_DEFAULT and smooth_value is None:
+        smooth_value = SMOOTH_VALUE_DEFAULT[smooth_method]
 
     precisions = [0 for x in range(NGRAM_ORDER)]
 
@@ -1333,7 +1333,7 @@ def compute_bleu(correct: List[int],
 def sentence_bleu(hypothesis: str,
                   references: List[str],
                   smooth_method: str = 'floor',
-                  smooth_value: float = SMOOTH_VALUE_DEFAULT,
+                  smooth_value: float = None,
                   use_effective_order: bool = True) -> BLEU:
     """
     Computes BLEU on a single sentence pair.
@@ -1357,7 +1357,7 @@ def sentence_bleu(hypothesis: str,
 def corpus_bleu(sys_stream: Union[str, Iterable[str]],
                 ref_streams: Union[str, List[Iterable[str]]],
                 smooth_method='exp',
-                smooth_value=SMOOTH_VALUE_DEFAULT,
+                smooth_value=None,
                 force=False,
                 lowercase=False,
                 tokenize=DEFAULT_TOKENIZER,
@@ -1423,7 +1423,7 @@ def corpus_bleu(sys_stream: Union[str, Iterable[str]],
 
 def raw_corpus_bleu(sys_stream,
                     ref_streams,
-                    smooth_value=SMOOTH_VALUE_DEFAULT) -> BLEU:
+                    smooth_value=None) -> BLEU:
     """Convenience function that wraps corpus_bleu().
     This is convenient if you're using sacrebleu as a library, say for scoring on dev.
     It uses no tokenization and 'floor' smoothing, with the floor default to 0 (no smoothing).
@@ -1613,8 +1613,8 @@ def main():
                             help='Output metric on each sentence.')
     arg_parser.add_argument('--smooth', '-s', choices=['exp', 'floor', 'add-k', 'none'], default='exp',
                             help='smoothing method: exponential decay (default), floor (increment zero counts), add-k (increment num/denom by k for n>1), or none')
-    arg_parser.add_argument('--smooth-value', '-sv', type=float, default=SMOOTH_VALUE_DEFAULT,
-                            help='The value to pass to the smoothing technique, when relevant. Default: %(default)s.')
+    arg_parser.add_argument('--smooth-value', '-sv', type=float, default=None,
+                            help='The value to pass to the smoothing technique, only used for floor and add-k. Default floor: {}, add-k: {}.'.format(SMOOTH_VALUE_DEFAULT['floor'], SMOOTH_VALUE_DEFAULT['add-k']))
     arg_parser.add_argument('--tokenize', '-tok', choices=TOKENIZERS.keys(), default=None,
                             help='tokenization method to use')
     arg_parser.add_argument('--language-pair', '-l', dest='langpair', default=None,


### PR DESCRIPTION
The smoothing value k is only added to the nominator and denominator for n-grams with n > 2 due to an off-by-one error. This is now fixed.