### PR TITLE
Conditionally install typing dependency only for python < 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # VERSION HISTORY
+- 1.5.0 (2020-05-11)
+  - Now only lists the external [typing](https://pypi.org/project/typing/)
+module as a dependency for Python <= 3.4, as it was integrated in the standard
+library in Python 3.5 (Erwan de Lépinau @ErwanDL).
 
 - 1.4.9 (2020-04-30)
   - Changed `get_available_testsets()` to return a list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # VERSION HISTORY
-- 1.5.0 (2020-05-11)
+- 1.4.10 (2020-05-11)
   - Now only lists the external [typing](https://pypi.org/project/typing/)
 module as a dependency for Python <= 3.4, as it was integrated in the standard
 library in Python 3.5 (Erwan de Lépinau @ErwanDL).

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires = ['typing', 'portalocker'],
+    install_requires = ['typing;python_version<"3.5"', 'portalocker'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
For #77.

I kept the dependency to typing for python < 3.5 instead of removing it altogether as it was easy to do, so that the package will not break for users on old python versions. Consequently, shoud I change the version to 1.4.10 instead of 1.5.0 ?