### PR TITLE
Add license to sdist and binary distribution on pypi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+license_file = LICENSE.txt


### PR DESCRIPTION
Currently the license doesn't exist on the PyPi distribution
![image](https://user-images.githubusercontent.com/90008/82614746-6d963800-9b7d-11ea-8185-4115bc6930bf.png)
