### PR TITLE
Added support for character-based tokenisation.

### DIFF
--- a/sacrebleu/tokenizer.py
+++ b/sacrebleu/tokenizer.py
@@ -273,4 +273,5 @@ TOKENIZERS = {
     'zh': tokenize_zh,
     'ja-mecab': TokenizeMeCab().tokenize,
     'none': lambda x: x,
+    'char-based':  lambda x: ' '.join((char for char in line)),
 }


### PR DESCRIPTION
Hi, @mjpost,

I had added this `char-based` tokenisation option for OCELoT recently. It gives a cheap way to compute more useful scores for non-word-broken language scripts and can be used as a fallback when there is no tokenisation available (yet).

Cheers and best, have a good day,
   Christian