### PR TITLE
sentence_score needs a list of references, not a single string

### DIFF
--- a/sacrebleu/compat.py
+++ b/sacrebleu/compat.py
@@ -67,7 +67,7 @@ def sentence_bleu(hypothesis: str,
     BLEU is a corpus-level metric.
 
     :param hypothesis: Hypothesis string.
-    :param reference: Reference string.
+    :param references: List of reference strings.
     :param smooth_method: The smoothing method to use
     :param smooth_value: For 'floor' smoothing, the floor value to use.
     :param use_effective_order: Account for references that are shorter than the largest n-gram.

--- a/sacrebleu/metrics/bleu.py
+++ b/sacrebleu/metrics/bleu.py
@@ -219,10 +219,11 @@ class BLEU:
         BLEU is a corpus-level metric.
 
         :param hypothesis: Hypothesis string.
-        :param reference: Reference string.
+        :param references: List of reference strings.
         :param use_effective_order: Account for references that are shorter than the largest n-gram.
         :return: a `BLEUScore` object containing everything you'd want
         """
+        assert not isinstance(references, str), "sentence_score needs a list of references, not a single string"
         return self.corpus_score(hypothesis, [[ref] for ref in references],
                                  use_effective_order=use_effective_order)
 


### PR DESCRIPTION
If a single string is provided it is split into characters and each character is treated as one reference, which may be very confusing and difficult to debug.
The type hint `List[str]` could help if everyone is using some type checking such as `mypy`.