### PR TITLE
Add TER

### DIFF
--- a/sacrebleu/compat.py
+++ b/sacrebleu/compat.py
@@ -3,8 +3,8 @@
 from typing import Union, Iterable, List
 from argparse import Namespace
 
-from .tokenizers import DEFAULT_TOKENIZER
-from .metrics import BLEU, CHRF, BLEUScore, CHRFScore
+from .tokenizers import DEFAULT_TOKENIZER, TOKENIZERS
+from .metrics import BLEU, CHRF, TER, BLEUScore, CHRFScore, TERScore
 
 
 ######################################################################
@@ -121,4 +121,52 @@ def sentence_chrf(hypothesis: str,
     args = Namespace(
         chrf_order=order, chrf_beta=beta, chrf_whitespace=not remove_whitespace, short=False)
     metric = CHRF(args)
+    return metric.sentence_score(hypothesis, references)
+
+
+def corpus_ter(hypotheses: Iterable[str],
+               references: List[Iterable[str]],
+               normalized: bool = False,
+               no_punct: bool = False,
+               asian_support: bool = False,
+               case_sensitive: bool = False) -> TERScore:
+    """
+    Computes TER on a corpus.
+
+    :param hypotheses: Stream of hypotheses.
+    :param references: Stream of references.
+    :param normalized: Enable character normalization.
+    :param no_punct: Remove punctuation.
+    :param asian_support: Enable special treatment of Asian characters.
+    :param case_sensitive: Enable case sensitivity.
+    :return: A `TERScore` object.
+    """
+    tokenizer = TOKENIZERS['tercom'](
+        normalized=normalized, no_punct=no_punct,
+        asian_support=asian_support, case_sensitive=case_sensitive)
+    metric = TER(Namespace(), tokenizer)
+    return metric.corpus_score(hypotheses, references)
+
+
+def sentence_ter(hypothesis: str,
+                 references: Iterable[str],
+                 normalized: bool = False,
+                 no_punct: bool = False,
+                 asian_support: bool = False,
+                 case_sensitive: bool = False) -> TERScore:
+    """
+    Computes TER on a single sentence pair.
+
+    :param hypothesis: Hypothesis string.
+    :param references: Reference string(s).
+    :param normalized: Enable character normalization.
+    :param no_punct: Remove punctuation.
+    :param asian_support: Enable special treatment of Asian characters.
+    :param case_sensitive: Enable case sensitivity.
+    :return: A `TERScore` object.
+    """
+    tokenizer = TOKENIZERS['tercom'](
+        normalized=normalized, no_punct=no_punct,
+        asian_support=asian_support, case_sensitive=case_sensitive)
+    metric = TER(Namespace(), tokenizer)
     return metric.sentence_score(hypothesis, references)

--- a/sacrebleu/compat.py
+++ b/sacrebleu/compat.py
@@ -141,10 +141,10 @@ def corpus_ter(hypotheses: Iterable[str],
     :param case_sensitive: Enable case sensitivity.
     :return: A `TERScore` object.
     """
-    tokenizer = TOKENIZERS['tercom'](
+    args = Namespace(
         normalized=normalized, no_punct=no_punct,
         asian_support=asian_support, case_sensitive=case_sensitive)
-    metric = TER(Namespace(), tokenizer)
+    metric = TER(args)
     return metric.corpus_score(hypotheses, references)
 
 
@@ -165,8 +165,8 @@ def sentence_ter(hypothesis: str,
     :param case_sensitive: Enable case sensitivity.
     :return: A `TERScore` object.
     """
-    tokenizer = TOKENIZERS['tercom'](
+    args = Namespace(
         normalized=normalized, no_punct=no_punct,
         asian_support=asian_support, case_sensitive=case_sensitive)
-    metric = TER(Namespace(), tokenizer)
+    metric = TER(args)
     return metric.sentence_score(hypothesis, references)

--- a/sacrebleu/metrics/__init__.py
+++ b/sacrebleu/metrics/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from .bleu import BLEU
-from .chrf import CHRF
-from .ter import TER
+from .bleu import BLEU, BLEUScore
+from .chrf import CHRF, CHRFScore
+from .ter import TER, TERScore
 
 METRICS = {
     'bleu': BLEU,

--- a/sacrebleu/metrics/__init__.py
+++ b/sacrebleu/metrics/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from .bleu import BLEU, BLEUScore
-from .chrf import CHRF, CHRFScore
+from .bleu import BLEU
+from .chrf import CHRF
+from .ter import TER
 
 METRICS = {
     'bleu': BLEU,
     'chrf': CHRF,
+    'ter': TER,
 }

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -68,6 +68,11 @@ class TERScore(BaseScore):
         self.prefix = 'TER'
 
     def format(self, width=2, score_only=False, signature=''):
+        # the default width of 1 is too small for TER, it's reported with 3
+        # decimal places in matrix.statmt.org
+        if width == 1:
+            width = 3
+
         if score_only:
             return '{0:.{1}f}'.format(self.score, width)
 

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -1,0 +1,565 @@
+import math
+from typing import List, Tuple, Dict, Union, Iterable
+from itertools import zip_longest
+
+from ..tokenizers import TOKENIZERS
+from ..utils import my_log
+from .base import BaseScore, Signature
+
+# Translation edit rate (TER).
+#
+# Based partly on the PyTer package by Hiroyuki Tanaka (MIT license).
+#
+# https://github.com/aflc/pyter
+#
+# Both the algorithm and the preprocessing try to mimic the original TER Java
+# implementation (Tercom):
+#
+# https://github.com/jhclark/tercom
+
+_COST_INS = 1
+_COST_DEL = 1
+_COST_SUB = 1
+
+# Tercom-inspired limits
+_MAX_SHIFT_SIZE = 10
+_MAX_SHIFT_DIST = 50
+_BEAM_WIDTH = 20
+
+# Our own limits
+_MAX_CACHE_SIZE = 10000
+_MAX_SHIFT_CANDIDATES = 1000
+
+_OP_INS = 'i'
+_OP_DEL = 'd'
+_OP_NOP = ' '
+_OP_SUB = 's'
+_OP_UNDEF = 'x'
+
+
+class TERScore(BaseScore):
+    def __init__(self, num_edits, ref_length):
+        score = num_edits / ref_length
+        super().__init__(score)
+
+        self.num_edits = num_edits
+        self.ref_length = ref_length
+
+    def format(self, width=2, score_only=False, signature=''):
+        return str(self.score)
+
+    def __gt__(self, other):
+        if type(other) != TERScore:
+            raise TypeError()
+
+
+class TERSignature(Signature):
+    def __init__(self, args):
+        super().__init__(args)
+
+
+class TER:
+    def __init__(self, args):
+        self.tokenizer = TOKENIZERS[args.tokenize]()
+
+    def corpus_score(self, sys_stream: Union[str, Iterable[str]],
+                     ref_streams: Union[str, List[Iterable[str]]]) -> TERScore:
+        # Add some robustness to the input arguments
+        if isinstance(sys_stream, str):
+            sys_stream = [sys_stream]
+
+        if isinstance(ref_streams, str):
+            ref_streams = [[ref_streams]]
+
+        fhs = [sys_stream] + ref_streams
+
+        total_edits = 0
+        sum_ref_lengths = 0
+
+        for lines in zip_longest(*fhs):
+            if None in lines:
+                raise EOFError("Source and reference streams have different lengths!")
+            hypo, *refs = lines
+
+            words_hyp = self.tokenizer(hypo).split()
+
+            best_num_edits = None
+            ref_lengths = 0
+
+            for ref in refs:
+                words_ref = self.tokenizer(ref).split()
+                num_edits, ref_len = translation_edit_rate(words_hyp, words_ref)
+                ref_lengths += ref_len
+                if best_num_edits is None or num_edits < best_num_edits:
+                    best_num_edits = num_edits
+
+            total_edits += best_num_edits
+            sum_ref_lengths += (ref_lengths / len(refs))
+
+        return TERScore(total_edits, sum_ref_lengths)
+
+    def sentence_score(self, hypothesis: str, references: List[str]) \
+            -> TERScore:
+        return self.corpus_score(hypothesis, [[ref] for ref in references])
+
+
+def translation_edit_rate(words_hyp: List[str], words_ref: List[str]) -> \
+        Tuple[int, int]:
+    """Calculate the translation edit rate.
+
+    Args:
+        words_hyp: Tokenized translation hypothesis.
+        words_ref: Tokenized reference translation.
+
+    Returns:
+        tuple (number of edits, length)
+    """
+    if len(words_ref) == 0:
+        trace = _OP_DEL * len(words_hyp)
+        # special treatment of empty refs
+        return (len(words_hyp), 0)
+
+    cached_ed = BeamEditDistance(words_ref)
+    shifts = 0
+
+    input_words = words_hyp
+    checked_candidates = 0
+    while True:
+        # do shifts until they stop reducing the edit distance
+        delta, new_input_words, checked_candidates = _shift(
+            input_words, words_ref, cached_ed, checked_candidates)
+
+        if checked_candidates >= _MAX_SHIFT_CANDIDATES:
+            break
+
+        if delta <= 0:
+            break
+        shifts += 1
+        input_words = new_input_words
+
+    edit_distance, trace = cached_ed(input_words)
+    total_edits = shifts + edit_distance
+
+    return (total_edits, len(words_ref))
+
+
+def _shift(words_h: List[str], words_r: List[str], cached_ed,
+           checked_candidates: int) -> Tuple[int, List[str], int]:
+    """Attempt to shift words in hypothesis to match reference.
+
+    Returns the shift that reduces the edit distance the most.
+
+    Note that the filtering of possible shifts and shift selection are heavily
+    based on somewhat arbitrary heuristics. The code here follows as closely
+    as possible the logic in Tercom, not always justifying the particular design
+    choices.
+
+    Args:
+        words_h: Hypothesis.
+        words_r: Reference.
+        cached_ed: Cached edit distance.
+        checked_candidates: Number of shift candidates that were already
+            evaluated.
+
+    Returns:
+        (score, shifted_words, checked_candidates). Best shift and updated
+            number of evaluated shift candidates.
+    """
+    pre_score, inv_trace = cached_ed(words_h)
+
+    # to get alignment, we pretend we are rewriting reference into hypothesis,
+    # so we need to flip the trace of edit operations
+    trace = _flip_trace(inv_trace)
+    align, ref_err, hyp_err = trace_to_alignment(trace)
+
+    best = None
+
+    for start_h, start_r, length in _find_shifted_pairs(words_h, words_r):
+        # don't do the shift unless both the hypothesis was wrong and the
+        # reference doesn't match hypothesis at the target position
+        if sum(hyp_err[start_h:start_h+length]) == 0:
+            continue
+
+        if sum(ref_err[start_r:start_r+length]) == 0:
+            continue
+
+        # don't try to shift within the subsequence
+        if start_h <= align[start_r] < start_h + length:
+            continue
+
+        prev_idx = -1
+        for offset in range(-1, length):
+            if start_r + offset == -1:
+                idx = 0  # insert before the beginning
+            elif start_r + offset in align:
+                # Unlike Tercom which inserts *after* the index, we insert
+                # *before* the index.
+                idx = align[start_r + offset] + 1
+            else:
+                break  # offset is out of bounds => aims past reference
+
+            if idx == prev_idx:
+                continue  # skip idx if already tried
+
+            prev_idx = idx
+
+            shifted_words = _perform_shift(words_h, start_h, length, idx)
+            assert(len(shifted_words) == len(words_h))
+
+            # Elements of the tuple are designed to replicate Tercom ranking
+            # of shifts:
+            candidate = (
+                pre_score - cached_ed(shifted_words)[0],  # highest score first
+                length,  # then, longest match first
+                -start_h,  # then, earliest match first
+                -idx,   # then, earliest target position first
+                shifted_words,
+            )
+
+            checked_candidates += 1
+
+            if not best or candidate > best:
+                best = candidate
+
+        if checked_candidates >= _MAX_SHIFT_CANDIDATES:
+            break
+
+    if not best:
+        return 0, words_h, checked_candidates
+    else:
+        best_score, _, _, _, shifted_words = best
+        return best_score, shifted_words, checked_candidates
+
+
+def _perform_shift(words: List[str], start: int, length: int, target: int):
+    """Perform a shift in `words` from `start` to `target`.
+
+    Args:
+        words: Words to shift.
+        start: Where from.
+        length: How many words.
+        target: Where to.
+
+    Returns:
+        List[str]. Shifted words.
+    """
+    if target < start:
+        # shift before previous position
+        return (words[:target] + words[start:start+length]
+                + words[target:start] + words[start+length:])
+    elif target > start + length:
+        # shift after previous position
+        return (words[:start] + words[start+length:target]
+                + words[start:start+length] + words[target:])
+    else:
+        # shift within the shifted string
+        return (words[:start] + words[start+length:length+target]
+                + words[start:start+length] + words[length+target:])
+
+
+def _find_shifted_pairs(words_h: List[str], words_r: List[str]):
+    """Find matching word sub-sequences in two lists of words.
+
+    Ignores sub-sequences starting at the same position.
+
+    Args:
+        words_h: First word list.
+        words_r: Second word list.
+
+    Returns:
+        Yields tuples of (h_start, r_start, length) such that:
+
+            words_h[h_start:h_start+length] = words_r[r_start:r_start+length]
+    """
+    for start_h in range(len(words_h)):
+        for start_r in range(len(words_r)):
+            # this is slightly different from what tercom does but this should
+            # really only kick in in degenerate cases
+            if abs(start_r - start_h) > _MAX_SHIFT_DIST:
+                continue
+
+            length = 0
+            while (words_h[start_h + length] == words_r[start_r + length]
+                   and length < _MAX_SHIFT_SIZE):
+                length += 1
+
+                if length != 0:
+                    yield start_h, start_r, length
+
+                if ((len(words_h) == start_h + length)
+                        or (len(words_r) == start_r + length)):
+                    break
+
+
+def _flip_trace(trace):
+    """Flip the trace of edit operations.
+
+    Instead of rewriting a->b, get a recipe for rewriting b->a.
+
+    Simply flips insertions and deletions.
+    """
+    ret = list(trace)
+    for i in range(len(ret)):
+        if ret[i] == _OP_INS:
+            ret[i] = _OP_DEL
+        elif ret[i] == _OP_DEL:
+            ret[i] = _OP_INS
+    return ''.join(ret)
+
+
+def trace_to_alignment(trace: str) -> Tuple[Dict, List, List]:
+    """Transform trace of edit operations into an alignment of the sequences.
+
+    Args:
+        trace: Trace of edit operations (' '=no change or 's'/'i'/'d').
+
+    Returns:
+        Alignment, error positions in reference, error positions in hypothesis.
+    """
+    pos_hyp = -1
+    pos_ref = -1
+    hyp_err = []
+    ref_err = []
+    align = {}
+
+    # we are rewriting a into b
+    for op in trace:
+        if op == _OP_NOP:
+            pos_hyp += 1
+            pos_ref += 1
+            align[pos_ref] = pos_hyp
+            hyp_err.append(0)
+            ref_err.append(0)
+        elif op == _OP_SUB:
+            pos_hyp += 1
+            pos_ref += 1
+            align[pos_ref] = pos_hyp
+            hyp_err.append(1)
+            ref_err.append(1)
+        elif op == _OP_INS:
+            pos_hyp += 1
+            hyp_err.append(1)
+        elif op == _OP_DEL:
+            pos_ref += 1
+            align[pos_ref] = pos_hyp
+            ref_err.append(1)
+        else:
+            raise Exception(f"unknown operation '{op}'")
+
+    return align, ref_err, hyp_err
+
+
+class BeamEditDistance:
+    """Edit distance with several features required for TER calculation.
+
+        * internal cache
+        * "beam" search
+        * tracking of edit operations
+
+    The internal self._cache works like this:
+
+    Keys are words of the hypothesis. Values are tuples (next_node, row) where:
+
+        * next_node is the cache for the next word in the sequence
+        * row is the stored row of the edit distance matrix
+
+    Effectively, caching allows to skip several rows in the edit distance
+    matrix calculation and instead, to initialize the computation with the last
+    matching matrix row.
+
+    Beam search, as implemented here, only explores a fixed-size sub-row of
+    candidates around the matrix diagonal (more precisely, it's a
+    "pseudo"-diagonal since we take the ratio of sequence lengths into account).
+
+    Tracking allows to reconstruct the optimal sequence of edit operations.
+    """
+    def __init__(self, words_ref: List[str]):
+        self._words_ref = words_ref
+
+        # first row corresponds to insertion operations of the reference,
+        # so we do 1 edit operation per reference word
+        self._initial_row = [(i * _COST_INS, _OP_INS)
+                             for i in range(len(self._words_ref) + 1)]
+
+        self._cache = {}
+        self._cache_size = 0
+
+        # Precomputed empty matrix row. Contains infinities so that beam search
+        # avoids using the uninitialized cells.
+        self._empty_row = [(math.inf, _OP_UNDEF)] * (len(self._words_ref) + 1)
+
+    def __call__(self, words_hyp: List[str]) -> Tuple[int, str]:
+        """Calculate edit distance between self._words_ref and the hypothesis.
+
+        Uses cache to skip some of the computation.
+
+        Args:
+            words_hyp: Words in translation hypothesis.
+
+        Returns:
+            Edit distance score.
+        """
+
+        # skip initial words in the hypothesis for which we already know the
+        # edit distance
+        start_position, dist = self._find_cache(words_hyp)
+
+        # calculate the rest of the edit distance matrix
+        edit_distance, newly_created_matrix, trace = self._edit_distance(
+            words_hyp, start_position, dist)
+
+        # update our cache with the newly calculated rows
+        self._add_cache(words_hyp, newly_created_matrix)
+
+        return edit_distance, trace
+
+    def _edit_distance(self, words_h: List[str], start_h: int,
+                       cache: List[List[Tuple]]) -> Tuple[int, List, str]:
+        """Actual edit distance calculation.
+
+        Can be initialized with the last cached row and a start position in
+        the hypothesis that it corresponds to.
+
+        Args:
+            words_h: Words in translation hypothesis.
+            start_h: Position from which to start the calculation.
+                (This is zero if no cache match was found.)
+            cache: Precomputed rows corresponding to edit distance matrix
+                before `start_h`.
+        Returns:
+            Edit distance value, newly computed rows to update the cache, trace.
+        """
+
+        # initialize the rest of the matrix with infinite edit distances
+        rest_empty = [list(self._empty_row)
+                      for _ in range(len(words_h) - start_h)]
+
+        dist = cache + rest_empty
+
+        assert len(dist) == len(words_h) + 1
+
+        if words_h:
+            length_ratio = len(self._words_ref) / len(words_h)
+        else:
+            length_ratio = 1
+
+        # in some crazy sentences, the difference in length is so large that
+        # we may end up with zero overlap with previous row
+        if _BEAM_WIDTH < length_ratio / 2:
+            beam_width = math.ceil(length_ratio / 2 + _BEAM_WIDTH)
+        else:
+            beam_width = _BEAM_WIDTH
+
+        # calculate the Levenshtein distance
+        for i in range(start_h + 1, len(words_h) + 1):
+            pseudo_diag = math.floor(i * length_ratio)
+            min_j = max(0, pseudo_diag - beam_width)
+            max_j = min(len(self._words_ref) + 1, pseudo_diag + beam_width)
+
+            if i == len(words_h):
+                max_j = len(self._words_ref) + 1
+
+            for j in range(min_j, max_j):
+                if j == 0:
+                    dist[i][j] = (dist[i - 1][j][0] + _COST_DEL, _OP_DEL)
+                else:
+                    if words_h[i - 1] == self._words_ref[j - 1]:
+                        cost_sub = 0
+                        op_sub = _OP_NOP
+                    else:
+                        cost_sub = _COST_SUB
+                        op_sub = _OP_SUB
+
+                    # Tercom prefers no-op/sub, then insertion, then deletion.
+                    # But since we flip the trace and compute the alignment from
+                    # the inverse, we need to swap order of insertion and
+                    # deletion in the preference.
+                    ops = (
+                        (dist[i - 1][j - 1][0] + cost_sub, op_sub),
+                        (dist[i - 1][j][0] + _COST_DEL, _OP_DEL),
+                        (dist[i][j - 1][0] + _COST_INS, _OP_INS),
+                    )
+
+                    for op in ops:
+                        if dist[i][j][0] > op[0]:
+                            dist[i][j] = op
+
+        # get the trace
+        trace = ""
+        i = len(words_h)
+        j = len(self._words_ref)
+
+        while i > 0 or j > 0:
+            op = dist[i][j][1]
+            trace = op + trace
+            if op in (_OP_SUB, _OP_NOP):
+                i -= 1
+                j -= 1
+            elif op == _OP_INS:
+                j -= 1
+            elif op == _OP_DEL:
+                i -= 1
+            else:
+                raise Exception(f"unknown operation '{op}'")
+
+        return dist[-1][-1][0], dist[len(cache):], trace
+
+    def _add_cache(self, words_hyp: List[str], mat: List[List[Tuple]]):
+        """Add newly computed rows to cache.
+
+        Since edit distance is only calculated on the hypothesis suffix that
+        was not in cache, the number of rows in `mat` may be shorter than
+        hypothesis length. In that case, we skip over these initial words.
+
+        Args:
+            words_hyp: Hypothesis words.
+            mat: Edit distance matrix rows for each position.
+        """
+        if self._cache_size >= _MAX_CACHE_SIZE:
+            return
+
+        node = self._cache
+
+        # how many initial words to skip
+        skip_num = len(words_hyp) - len(mat)
+
+        # jump through the cache to the current position
+        for i in range(skip_num):
+            node = node[words_hyp[i]][0]
+
+        assert len(words_hyp[skip_num:]) == len(mat)
+
+        # update cache with newly computed rows
+        for word, row in zip(words_hyp[skip_num:], mat):
+            if word not in node:
+                node[word] = [{}, None]
+            value = node[word]
+            if value[1] is None:
+                value[1] = tuple(row)
+                self._cache_size += 1
+            node = value[0]
+
+    def _find_cache(self, words_hyp: List[str]) -> Tuple[int, List[List]]:
+        """Find the already computed rows of the edit distance matrix in cache.
+
+        Returns a partially computed edit distance matrix.
+
+        Args:
+            words_hyp: Translation hypothesis.
+
+        Returns:
+            Tuple (start position, dist).
+        """
+        node = self._cache
+        start_position = 0
+        dist = [self._initial_row]
+        for word in words_hyp:
+            if word in node:
+                start_position += 1
+                node, row = node[word]
+                dist.append(row)
+            else:
+                break
+
+        return start_position, dist
+

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -76,8 +76,9 @@ class TERScore(BaseScore):
 
 
 class TERSignature(Signature):
-    def __init__(self, args):
+    def __init__(self, args, tokenizer):
         super().__init__(args)
+        self.info.update({"tok": tokenizer.signature()})
 
 
 class TER:
@@ -86,7 +87,7 @@ class TER:
             tokenizer = TOKENIZERS['tercom']()
 
         self.tokenizer = tokenizer
-        self.signature = TERSignature(args)
+        self.signature = TERSignature(args, tokenizer)
 
     def corpus_score(self, sys_stream: Union[str, Iterable[str]],
                      ref_streams: Union[str, List[Iterable[str]]]) -> TERScore:

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -48,10 +48,6 @@ class TERScore(BaseScore):
     def format(self, width=2, score_only=False, signature=''):
         return str(self.score)
 
-    def __gt__(self, other):
-        if type(other) != TERScore:
-            raise TypeError()
-
 
 class TERSignature(Signature):
     def __init__(self, args):

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -1,3 +1,18 @@
+# Copyright 2020 Memsource
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import math
 from typing import List, Tuple, Dict, Union, Iterable
 from itertools import zip_longest

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -3,19 +3,25 @@ from typing import List, Tuple, Dict, Union, Iterable
 from itertools import zip_longest
 
 from ..tokenizers import TOKENIZERS
-from ..utils import my_log
 from .base import BaseScore, Signature
 
 # Translation edit rate (TER).
 #
-# Based partly on the PyTer package by Hiroyuki Tanaka (MIT license).
+# A near-exact reimplementation of the Tercom algorithm, produces identical
+# results on all "sane" outputs.
 #
-# https://github.com/aflc/pyter
+# The beam edit distance algorithm uses a slightly different approach (we stay
+# around the diagonal which is faster, at least in Python) so in some
+# (extreme) corner cases, the output could differ.
 #
-# Both the algorithm and the preprocessing try to mimic the original TER Java
-# implementation (Tercom):
+# Tercom original implementation:
 #
 # https://github.com/jhclark/tercom
+#
+# Caching in the edit distance is based partly on the PyTer package by Hiroyuki
+# Tanaka (MIT license).
+#
+# https://github.com/aflc/pyter
 
 _COST_INS = 1
 _COST_DEL = 1

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -61,7 +61,7 @@ class TERSignature(Signature):
 
 class TER:
     def __init__(self, args):
-        self.tokenizer = TOKENIZERS[args.tokenize]()
+        self.tokenizer = TOKENIZERS['tercom']()
         self.signature = TERSignature(args)
 
     def corpus_score(self, sys_stream: Union[str, Iterable[str]],

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -62,6 +62,7 @@ class TERSignature(Signature):
 class TER:
     def __init__(self, args):
         self.tokenizer = TOKENIZERS[args.tokenize]()
+        self.signature = TERSignature(args)
 
     def corpus_score(self, sys_stream: Union[str, Iterable[str]],
                      ref_streams: Union[str, List[Iterable[str]]]) -> TERScore:
@@ -345,7 +346,7 @@ def trace_to_alignment(trace: str) -> Tuple[Dict, List, List]:
             align[pos_ref] = pos_hyp
             ref_err.append(1)
         else:
-            raise Exception(f"unknown operation '{op}'")
+            raise Exception("unknown operation '{}'".format(op))
 
     return align, ref_err, hyp_err
 
@@ -501,7 +502,7 @@ class BeamEditDistance:
             elif op == _OP_DEL:
                 i -= 1
             else:
-                raise Exception(f"unknown operation '{op}'")
+                raise Exception("unknown operation '{}'".format(op))
 
         return dist[-1][-1][0], dist[len(cache):], trace
 

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -39,7 +39,7 @@ _OP_UNDEF = 'x'
 
 class TERScore(BaseScore):
     def __init__(self, num_edits, ref_length):
-        score = num_edits / ref_length
+        score = num_edits / ref_length if ref_length > 0 else 1
         super().__init__(score)
 
         self.num_edits = num_edits

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -44,9 +44,14 @@ class TERScore(BaseScore):
 
         self.num_edits = num_edits
         self.ref_length = ref_length
+        self.prefix = 'TER'
 
     def format(self, width=2, score_only=False, signature=''):
-        return str(self.score)
+        if score_only:
+            return '{0:.{1}f}'.format(self.score, width)
+
+        prefix = "{}+{}".format(self.prefix, signature) if signature else self.prefix
+        return '{pr} = {sc:.{w}f}'.format(pr=prefix, sc=self.score, w=width)
 
 
 class TERSignature(Signature):
@@ -113,7 +118,7 @@ def translation_edit_rate(words_hyp: List[str], words_ref: List[str]) -> \
     if len(words_ref) == 0:
         trace = _OP_DEL * len(words_hyp)
         # special treatment of empty refs
-        return (len(words_hyp), 0)
+        return len(words_hyp), 0
 
     cached_ed = BeamEditDistance(words_ref)
     shifts = 0
@@ -136,7 +141,7 @@ def translation_edit_rate(words_hyp: List[str], words_ref: List[str]) -> \
     edit_distance, trace = cached_ed(input_words)
     total_edits = shifts + edit_distance
 
-    return (total_edits, len(words_ref))
+    return total_edits, len(words_ref)
 
 
 def _shift(words_h: List[str], words_r: List[str], cached_ed,

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -81,8 +81,11 @@ class TERSignature(Signature):
 
 
 class TER:
-    def __init__(self, args):
-        self.tokenizer = TOKENIZERS['tercom']()
+    def __init__(self, args, tokenizer=None):
+        if tokenizer is None:
+            tokenizer = TOKENIZERS['tercom']()
+
+        self.tokenizer = tokenizer
         self.signature = TERSignature(args)
 
     def corpus_score(self, sys_stream: Union[str, Iterable[str]],

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -132,12 +132,9 @@ class TER:
 def translation_edit_rate(words_hyp: List[str], words_ref: List[str]) -> Tuple[int, int]:
     """Calculate the translation edit rate.
 
-    Args:
-        words_hyp: Tokenized translation hypothesis.
-        words_ref: Tokenized reference translation.
-
-    Returns:
-        tuple (number of edits, length)
+    :param words_hyp: Tokenized translation hypothesis.
+    :param words_ref: Tokenized reference translation.
+    :return: tuple (number of edits, length)
     """
     if len(words_ref) == 0:
         trace = _OP_DEL * len(words_hyp)
@@ -179,16 +176,13 @@ def _shift(words_h: List[str], words_r: List[str], cached_ed,
     as possible the logic in Tercom, not always justifying the particular design
     choices.
 
-    Args:
-        words_h: Hypothesis.
-        words_r: Reference.
-        cached_ed: Cached edit distance.
-        checked_candidates: Number of shift candidates that were already
-            evaluated.
-
-    Returns:
-        (score, shifted_words, checked_candidates). Best shift and updated
-            number of evaluated shift candidates.
+    :param words_h: Hypothesis.
+    :param words_r: Reference.
+    :param cached_ed: Cached edit distance.
+    :param checked_candidates: Number of shift candidates that were already
+                               evaluated.
+    :return: (score, shifted_words, checked_candidates). Best shift and updated
+             number of evaluated shift candidates.
     """
     pre_score, inv_trace = cached_ed(words_h)
 
@@ -256,17 +250,14 @@ def _shift(words_h: List[str], words_r: List[str], cached_ed,
         return best_score, shifted_words, checked_candidates
 
 
-def _perform_shift(words: List[str], start: int, length: int, target: int):
+def _perform_shift(words: List[str], start: int, length: int, target: int) -> List[str]:
     """Perform a shift in `words` from `start` to `target`.
 
-    Args:
-        words: Words to shift.
-        start: Where from.
-        length: How many words.
-        target: Where to.
-
-    Returns:
-        List[str]. Shifted words.
+    :param words: Words to shift.
+    :param start: Where from.
+    :param length: How many words.
+    :param target: Where to.
+    :return: Shifted words.
     """
     if target < start:
         # shift before previous position
@@ -287,14 +278,11 @@ def _find_shifted_pairs(words_h: List[str], words_r: List[str]):
 
     Ignores sub-sequences starting at the same position.
 
-    Args:
-        words_h: First word list.
-        words_r: Second word list.
+    :param words_h: First word list.
+    :param words_r: Second word list.
+    :return: Yields tuples of (h_start, r_start, length) such that:
 
-    Returns:
-        Yields tuples of (h_start, r_start, length) such that:
-
-            words_h[h_start:h_start+length] = words_r[r_start:r_start+length]
+             words_h[h_start:h_start+length] = words_r[r_start:r_start+length]
     """
     for start_h in range(len(words_h)):
         for start_r in range(len(words_r)):
@@ -335,11 +323,8 @@ def _flip_trace(trace):
 def trace_to_alignment(trace: str) -> Tuple[Dict, List, List]:
     """Transform trace of edit operations into an alignment of the sequences.
 
-    Args:
-        trace: Trace of edit operations (' '=no change or 's'/'i'/'d').
-
-    Returns:
-        Alignment, error positions in reference, error positions in hypothesis.
+    :param trace: Trace of edit operations (' '=no change or 's'/'i'/'d').
+    :return: Alignment, error positions in reference, error positions in hypothesis.
     """
     pos_hyp = -1
     pos_ref = -1
@@ -418,11 +403,8 @@ class BeamEditDistance:
 
         Uses cache to skip some of the computation.
 
-        Args:
-            words_hyp: Words in translation hypothesis.
-
-        Returns:
-            Edit distance score.
+        :param words_hyp: Words in translation hypothesis.
+        :return: Edit distance score.
         """
 
         # skip initial words in the hypothesis for which we already know the
@@ -445,14 +427,13 @@ class BeamEditDistance:
         Can be initialized with the last cached row and a start position in
         the hypothesis that it corresponds to.
 
-        Args:
-            words_h: Words in translation hypothesis.
-            start_h: Position from which to start the calculation.
-                (This is zero if no cache match was found.)
-            cache: Precomputed rows corresponding to edit distance matrix
-                before `start_h`.
-        Returns:
-            Edit distance value, newly computed rows to update the cache, trace.
+        :param words_h: Words in translation hypothesis.
+        :param start_h: Position from which to start the calculation.
+                        (This is zero if no cache match was found.)
+        :param cache: Precomputed rows corresponding to edit distance matrix
+                      before `start_h`.
+        :return: Edit distance value, newly computed rows to update the
+                 cache, trace.
         """
 
         # initialize the rest of the matrix with infinite edit distances
@@ -536,9 +517,8 @@ class BeamEditDistance:
         was not in cache, the number of rows in `mat` may be shorter than
         hypothesis length. In that case, we skip over these initial words.
 
-        Args:
-            words_hyp: Hypothesis words.
-            mat: Edit distance matrix rows for each position.
+        :param words_hyp: Hypothesis words.
+        :param mat: Edit distance matrix rows for each position.
         """
         if self._cache_size >= _MAX_CACHE_SIZE:
             return
@@ -569,11 +549,8 @@ class BeamEditDistance:
 
         Returns a partially computed edit distance matrix.
 
-        Args:
-            words_hyp: Translation hypothesis.
-
-        Returns:
-            Tuple (start position, dist).
+        :param words_hyp: Translation hypothesis.
+        :return: Tuple (start position, dist).
         """
         node = self._cache
         start_position = 0

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -125,13 +125,11 @@ class TER:
 
         return TERScore(total_edits, sum_ref_lengths)
 
-    def sentence_score(self, hypothesis: str, references: List[str]) \
-            -> TERScore:
+    def sentence_score(self, hypothesis: str, references: List[str]) -> TERScore:
         return self.corpus_score(hypothesis, [[ref] for ref in references])
 
 
-def translation_edit_rate(words_hyp: List[str], words_ref: List[str]) -> \
-        Tuple[int, int]:
+def translation_edit_rate(words_hyp: List[str], words_ref: List[str]) -> Tuple[int, int]:
     """Calculate the translation edit rate.
 
     Args:

--- a/sacrebleu/metrics/ter.py
+++ b/sacrebleu/metrics/ter.py
@@ -45,7 +45,7 @@ _COST_SUB = 1
 # Tercom-inspired limits
 _MAX_SHIFT_SIZE = 10
 _MAX_SHIFT_DIST = 50
-_BEAM_WIDTH = 20
+_BEAM_WIDTH = 25
 
 # Our own limits
 _MAX_CACHE_SIZE = 10000

--- a/sacrebleu/sacrebleu.py
+++ b/sacrebleu/sacrebleu.py
@@ -208,6 +208,10 @@ def main():
         logging.warning("You are turning off sacrebleu's internal tokenization ('--tokenize none'), presumably to supply\n"
                         "your own reference tokenization. Published numbers will not be comparable with other papers.\n")
 
+    if 'ter' in args.metrics and args.tokenize is not None:
+        logging.warning("Your setting of --tokenize will be ignored when "
+                        "computing TER")
+
     # Internal tokenizer settings
     if args.tokenize is None:
         # set default

--- a/sacrebleu/tokenizers/__init__.py
+++ b/sacrebleu/tokenizers/__init__.py
@@ -5,6 +5,7 @@ from .tokenizer_13a import Tokenizer13a
 from .tokenizer_intl import TokenizerV14International
 from .tokenizer_zh import TokenizerZh
 from .tokenizer_ja_mecab import TokenizerJaMecab
+from .tokenizer_ter import TercomTokenizer
 
 
 DEFAULT_TOKENIZER = '13a'
@@ -16,4 +17,5 @@ TOKENIZERS = {
     'intl': TokenizerV14International,
     'zh': TokenizerZh,
     'ja-mecab': TokenizerJaMecab,
+    'tercom': TercomTokenizer
 }

--- a/sacrebleu/tokenizers/__init__.py
+++ b/sacrebleu/tokenizers/__init__.py
@@ -5,7 +5,6 @@ from .tokenizer_13a import Tokenizer13a
 from .tokenizer_intl import TokenizerV14International
 from .tokenizer_zh import TokenizerZh
 from .tokenizer_ja_mecab import TokenizerJaMecab
-from .tokenizer_ter import TercomTokenizer
 
 
 DEFAULT_TOKENIZER = '13a'
@@ -17,5 +16,4 @@ TOKENIZERS = {
     'intl': TokenizerV14International,
     'zh': TokenizerZh,
     'ja-mecab': TokenizerJaMecab,
-    'tercom': TercomTokenizer
 }

--- a/sacrebleu/tokenizers/tokenizer_ter.py
+++ b/sacrebleu/tokenizers/tokenizer_ter.py
@@ -1,0 +1,142 @@
+import re
+
+from .tokenizer_none import NoneTokenizer
+
+
+def _normalize_general_and_western(sent: str) -> str:
+    # language-independent (general) part
+
+    # strip end-of-line hyphenation and join lines
+    sent = re.sub(r"\n-", "", sent)
+
+    # join lines
+    sent = re.sub(r"\n", " ", sent)
+
+    # handle XML escaped symbols
+    sent = re.sub(r"&quot;", "\"", sent)
+    sent = re.sub(r"&amp;", "&", sent)
+    sent = re.sub(r"&lt;", "<", sent)
+    sent = re.sub(r"&gt;", ">", sent)
+
+    # language-dependent (Western) part
+    sent = f" {sent} "
+
+    # tokenize punctuation
+    sent = re.sub(r"([{-~[-` -&(-+:-@/])", r" \1 ", sent)
+
+    # handle possesives
+    sent = re.sub(r"'s ", r" 's ", sent)
+    sent = re.sub(r"'s$", r" 's", sent)
+
+    # tokenize period and comma unless preceded by a digit
+    sent = re.sub(r"([^0-9])([\.,])", r"\1 \2 ", sent)
+
+    # tokenize period and comma unless followed by a digit
+    sent = re.sub(r"([\.,])([^0-9])", r" \1 \2", sent)
+
+    # tokenize dash when preceded by a digit
+    sent = re.sub(r"([0-9])(-)", r"\1 \2 ", sent)
+
+    return sent
+
+
+def _normalize_asian(sent: str) -> str:
+    # Split Chinese chars and Japanese kanji down to character level
+
+    # 4E00—9FFF CJK Unified Ideographs
+    # 3400—4DBF CJK Unified Ideographs Extension A
+    sent = re.sub(r"([\u4e00-\u9fff\u3400-\u4dbf])", r" \1 ", sent)
+
+    # 31C0—31EF CJK Strokes
+    # 2E80—2EFF CJK Radicals Supplement
+    sent = re.sub(r"([\u31c0-\u31ef\u2e80-\u2eff])", r" \1 ", sent)
+
+    # 3300—33FF CJK Compatibility
+    # F900—FAFF CJK Compatibility Ideographs
+    # FE30—FE4F CJK Compatibility Forms
+    sent = re.sub(
+        r"([\u3300-\u33ff\uf900-\ufaff\ufe30-\ufe4f])", r" \1 ", sent)
+
+    # 3200—32FF Enclosed CJK Letters and Months
+    sent = re.sub(r"([\u3200-\u3f22])", r" \1 ", sent)
+
+    # Split Hiragana, Katakana, and KatakanaPhoneticExtensions
+    # only when adjacent to something else
+    # 3040—309F Hiragana
+    # 30A0—30FF Katakana
+    # 31F0—31FF Katakana Phonetic Extensions
+    sent = re.sub(
+        r"(^|^[\u3040-\u309f])([\u3040-\u309f]+)(?=$|^[\u3040-\u309f])",
+        r"\1 \2 ", sent)
+    sent = re.sub(
+        r"(^|^[\u30a0-\u30ff])([\u30a0-\u30ff]+)(?=$|^[\u30a0-\u30ff])",
+        r"\1 \2 ", sent)
+    sent = re.sub(
+        r"(^|^[\u31f0-\u31ff])([\u31f0-\u31ff]+)(?=$|^[\u31f0-\u31ff])",
+        r"\1 \2 ", sent)
+
+    sent = re.sub(TercomTokenizer.ASIAN_PUNCT, r" \1 ", sent)
+    sent = re.sub(TercomTokenizer.FULL_WIDTH_PUNCT, r" \1 ", sent)
+    return sent
+
+
+def _remove_punct(sent: str) -> str:
+    return re.sub(r"[\.,\?:;!\"\(\)]", "", sent)
+
+
+def _remove_asian_punct(sent: str) -> str:
+    sent = re.sub(TercomTokenizer.ASIAN_PUNCT, r"", sent)
+    sent = re.sub(TercomTokenizer.FULL_WIDTH_PUNCT, r"", sent)
+    return sent
+
+
+class TercomTokenizer(NoneTokenizer):
+    """Re-implementation Tercom Tokenizer in Python 3.
+
+    See src/ter/core/Normalizer.java in https://github.com/jhclark/tercom
+
+    Note that Python doesn't support named Unicode blocks so the mapping for
+    relevant blocks was taken from here:
+
+    https://unicode-table.com/en/blocks/
+    """
+    ASIAN_PUNCT = \
+        r"([\u3001\u3002\u3008-\u3011\u3014-\u301f\uff61-\uff65\u30fb])"
+    FULL_WIDTH_PUNCT = \
+        r"([\uff0e\uff0c\uff1f\uff1a\uff1b\uff01\uff02\uff08\uff09])"
+
+    def __init__(self,
+                 normalized: bool = False,
+                 no_punct: bool = False,
+                 asian_support: bool = False,
+                 case_sensitive: bool = False):
+        self._normalized = normalized
+        self._no_punct = no_punct
+        self._asian_support = asian_support
+        self._case_sensitive = case_sensitive
+
+    def __call__(self, sent: str) -> str:
+        if not sent:
+            return ""
+
+        if not self._case_sensitive:
+            sent = sent.lower()
+
+        if self._normalized:
+            sent = _normalize_general_and_western(sent)
+            if self._asian_support:
+                sent = _normalize_asian(sent)
+
+            sent = re.sub(r"\s+", " ", sent)  # one space only between words
+            sent = re.sub(r"^\s+", "", sent)  # no leading space
+            sent = re.sub(r"\s+$", "", sent)  # no trailing space
+
+        if self._no_punct:
+            sent = _remove_punct(sent)
+            if self._asian_support:
+                sent = _remove_asian_punct(sent)
+
+        return sent
+    
+    def signature(self):
+        return "ter"

--- a/sacrebleu/tokenizers/tokenizer_ter.py
+++ b/sacrebleu/tokenizers/tokenizer_ter.py
@@ -139,4 +139,10 @@ class TercomTokenizer(NoneTokenizer):
         return sent
     
     def signature(self):
-        return "ter"
+        return("-".join([
+            'ter',
+            'norm' if self._normalized else 'nonorm',
+            'nopunct' if self._no_punct else 'punct',
+            'asian' if self._asian_support else 'noasian',
+            'cased' if self._case_sensitive else 'uncased',
+        ]))

--- a/sacrebleu/tokenizers/tokenizer_ter.py
+++ b/sacrebleu/tokenizers/tokenizer_ter.py
@@ -125,6 +125,13 @@ class TercomTokenizer(NoneTokenizer):
                  no_punct: bool = False,
                  asian_support: bool = False,
                  case_sensitive: bool = False):
+        """Initialize the tokenizer.
+
+        :param normalized: Enable character normalization.
+        :param no_punct: Remove punctuation.
+        :param asian_support: Enable special treatment of Asian characters.
+        :param case_sensitive: Enable case sensitivity.
+        """
         self._normalized = normalized
         self._no_punct = no_punct
         self._asian_support = asian_support

--- a/sacrebleu/tokenizers/tokenizer_ter.py
+++ b/sacrebleu/tokenizers/tokenizer_ter.py
@@ -1,3 +1,18 @@
+# Copyright 2020 Memsource
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import re
 
 from .tokenizer_none import NoneTokenizer

--- a/sacrebleu/tokenizers/tokenizer_ter.py
+++ b/sacrebleu/tokenizers/tokenizer_ter.py
@@ -19,7 +19,7 @@ def _normalize_general_and_western(sent: str) -> str:
     sent = re.sub(r"&gt;", ">", sent)
 
     # language-dependent (Western) part
-    sent = f" {sent} "
+    sent = " {} ".format(sent)
 
     # tokenize punctuation
     sent = re.sub(r"([{-~[-` -&(-+:-@/])", r" \1 ", sent)

--- a/sacrebleu/tokenizers/tokenizer_ter.py
+++ b/sacrebleu/tokenizers/tokenizer_ter.py
@@ -159,7 +159,7 @@ class TercomTokenizer(NoneTokenizer):
                 sent = _remove_asian_punct(sent)
 
         return sent
-    
+
     def signature(self):
         return("-".join([
             'tercom',

--- a/sacrebleu/tokenizers/tokenizer_ter.py
+++ b/sacrebleu/tokenizers/tokenizer_ter.py
@@ -115,10 +115,8 @@ class TercomTokenizer(NoneTokenizer):
 
     https://unicode-table.com/en/blocks/
     """
-    ASIAN_PUNCT = \
-        r"([\u3001\u3002\u3008-\u3011\u3014-\u301f\uff61-\uff65\u30fb])"
-    FULL_WIDTH_PUNCT = \
-        r"([\uff0e\uff0c\uff1f\uff1a\uff1b\uff01\uff02\uff08\uff09])"
+    ASIAN_PUNCT = r"([\u3001\u3002\u3008-\u3011\u3014-\u301f\uff61-\uff65\u30fb])"
+    FULL_WIDTH_PUNCT = r"([\uff0e\uff0c\uff1f\uff1a\uff1b\uff01\uff02\uff08\uff09])"
 
     def __init__(self,
                  normalized: bool = False,

--- a/sacrebleu/tokenizers/tokenizer_ter.py
+++ b/sacrebleu/tokenizers/tokenizer_ter.py
@@ -140,7 +140,7 @@ class TercomTokenizer(NoneTokenizer):
     
     def signature(self):
         return("-".join([
-            'ter',
+            'tercom',
             'norm' if self._normalized else 'nonorm',
             'nopunct' if self._no_punct else 'punct',
             'asian' if self._asian_support else 'noasian',

--- a/test.sh
+++ b/test.sh
@@ -671,7 +671,6 @@ if [ -z $SKIP_TER ]; then
 
           score=$(cat $txt | ${CMD} -w 3 -t wmt17 -l $source-$target -b --metrics ter)
 
-          # rescale to 0-1
           expected_score="${TER[$name]}"
 
           echo "import sys; sys.exit(1 if abs(${score}-${expected_score}) > 0.01 else 0)" | python

--- a/test.sh
+++ b/test.sh
@@ -35,6 +35,7 @@ CMD="python3 -m sacrebleu"
 limit_test=${1:-}
 
 SKIP_CHRF=${SKIP_CHRF:-}
+SKIP_TER=${SKIP_TER:-}
 SKIP_MECAB=${SKIP_MECAB:-}
 
 # TEST 1: download and process WMT17 data
@@ -561,6 +562,130 @@ for pair in cs-en de-en en-cs en-de en-fi en-lv en-ru en-tr en-zh fi-en lv-en ru
         let i++
     done
 done
+
+#######################################################
+# Pre-computed TER scores from official implementation
+# Cmd: java -jar tercom.7.25.jar -r REF -h HYP | grep '^Total TER' | awk '{ printf "%.3f\n", $3 }'
+#######################################################
+declare -A TER=( ["newstest2017.online-A.0.cs-en.sgm"]=0.637
+                 ["newstest2017.online-B.0.cs-en.sgm"]=0.605
+                 ["newstest2017.PJATK.4760.cs-en.sgm"]=0.664
+                 ["newstest2017.uedin-nmt.4955.cs-en.sgm"]=0.584
+                 ["newstest2017.CU-Chimera.4886.en-cs.sgm"]=0.696
+                 ["newstest2017.limsi-factored-norm.4957.en-cs.sgm"]=0.696
+                 ["newstest2017.LIUM-FNMT.4852.en-cs.sgm"]=0.699
+                 ["newstest2017.LIUM-NMT.4947.en-cs.sgm"]=0.701
+                 ["newstest2017.online-A.0.en-cs.sgm"]=0.743
+                 ["newstest2017.online-B.0.en-cs.sgm"]=0.703
+                 ["newstest2017.PJATK.4761.en-cs.sgm"]=0.757
+                 ["newstest2017.uedin-nmt.4956.en-cs.sgm"]=0.667
+                 ["newstest2017.C-3MA.4959.en-de.sgm"]=0.669
+                 ["newstest2017.FBK.4870.en-de.sgm"]=0.636
+                 ["newstest2017.KIT.4950.en-de.sgm"]=0.641
+                 ["newstest2017.LIUM-NMT.4900.en-de.sgm"]=0.633
+                 ["newstest2017.LMU-nmt-reranked.4934.en-de.sgm"]=0.618
+                 ["newstest2017.LMU-nmt-single.4893.en-de.sgm"]=0.626
+                 ["newstest2017.online-A.0.en-de.sgm"]=0.690
+                 ["newstest2017.online-B.0.en-de.sgm"]=0.632
+                 ["newstest2017.online-F.0.en-de.sgm"]=0.756
+                 ["newstest2017.online-G.0.en-de.sgm"]=0.733
+                 ["newstest2017.PROMT-Rule-based.4735.en-de.sgm"]=0.752
+                 ["newstest2017.RWTH-nmt-ensemble.4921.en-de.sgm"]=0.628
+                 ["newstest2017.SYSTRAN.4847.en-de.sgm"]=0.611
+                 ["newstest2017.TALP-UPC.4834.en-de.sgm"]=0.685
+                 ["newstest2017.uedin-nmt.4722.en-de.sgm"]=0.612
+                 ["newstest2017.xmu.4910.en-de.sgm"]=0.622
+                 ["newstest2017.AaltoHnmtFlatcat.4798.en-fi.sgm"]=0.750
+                 ["newstest2017.AaltoHnmtMultitask.4873.en-fi.sgm"]=0.673
+                 ["newstest2017.apertium-unconstrained.4769.en-fi.sgm"]=1.246
+                 ["newstest2017.HY-AH.4797.en-fi.sgm"]=0.857
+                 ["newstest2017.HY-HNMT.4961.en-fi.sgm"]=0.676
+                 ["newstest2017.HY-SMT.4882.en-fi.sgm"]=0.754
+                 ["newstest2017.jhu-nmt-lattice-rescore.4903.en-fi.sgm"]=0.758
+                 ["newstest2017.jhu-pbmt.4968.en-fi.sgm"]=0.778
+                 ["newstest2017.online-A.0.en-fi.sgm"]=0.761
+                 ["newstest2017.online-B.0.en-fi.sgm"]=0.665
+                 ["newstest2017.online-G.0.en-fi.sgm"]=0.767
+                 ["newstest2017.TALP-UPC.4939.en-fi.sgm"]=0.806
+                 ["newstest2017.C-3MA.5069.en-lv.sgm"]=0.843
+                 ["newstest2017.HY-HNMT.5066.en-lv.sgm"]=0.786
+                 ["newstest2017.jhu-pbmt.4969.en-lv.sgm"]=0.815
+                 ["newstest2017.KIT.5062.en-lv.sgm"]=0.773
+                 ["newstest2017.limsi-factored-norm.5041.en-lv.sgm"]=0.780
+                 ["newstest2017.LIUM-FNMT.5043.en-lv.sgm"]=0.780
+                 ["newstest2017.LIUM-NMT.5042.en-lv.sgm"]=0.769
+                 ["newstest2017.online-A.0.en-lv.sgm"]=0.846
+                 ["newstest2017.online-B.0.en-lv.sgm"]=0.754
+                 ["newstest2017.PJATK.4744.en-lv.sgm"]=0.868
+                 ["newstest2017.tilde-c-nmt-smt-hybrid.5049.en-lv.sgm"]=0.731
+                 ["newstest2017.tilde-nc-nmt-smt-hybrid.5047.en-lv.sgm"]=0.721
+                 ["newstest2017.tilde-nc-smt.5044.en-lv.sgm"]=0.747
+                 ["newstest2017.uedin-nmt.5016.en-lv.sgm"]=0.772
+                 ["newstest2017.usfd-consensus-kit.5078.en-lv.sgm"]=0.950
+                 ["newstest2017.usfd-consensus-qt21.5077.en-lv.sgm"]=0.946
+                 ["newstest2017.afrl-mitll-backtrans.4907.en-ru.sgm"]=0.655
+                 ["newstest2017.jhu-pbmt.4986.en-ru.sgm"]=0.658
+                 ["newstest2017.online-A.0.en-ru.sgm"]=0.661
+                 ["newstest2017.online-B.0.en-ru.sgm"]=0.563
+                 ["newstest2017.online-F.0.en-ru.sgm"]=0.809
+                 ["newstest2017.online-G.0.en-ru.sgm"]=0.618
+                 ["newstest2017.PROMT-Rule-based.4736.en-ru.sgm"]=0.667
+                 ["newstest2017.uedin-nmt.4756.en-ru.sgm"]=0.614
+                 ["newstest2017.JAIST.4858.en-tr.sgm"]=0.875
+                 ["newstest2017.jhu-nmt-lattice-rescore.4904.en-tr.sgm"]=0.864
+                 ["newstest2017.jhu-pbmt.4970.en-tr.sgm"]=0.874
+                 ["newstest2017.LIUM-NMT.4953.en-tr.sgm"]=0.752
+                 ["newstest2017.online-A.0.en-tr.sgm"]=0.787
+                 ["newstest2017.online-B.0.en-tr.sgm"]=0.677
+                 ["newstest2017.uedin-nmt.4932.en-tr.sgm"]=0.747
+                 ["newstest2017.CASICT-DCU-NMT.5157.en-zh.sgm"]=0.999
+                 ["newstest2017.online-A.0.en-zh.sgm"]=2.936
+                 ["newstest2017.online-B.0.en-zh.sgm"]=1.092
+                 ["newstest2017.online-F.0.en-zh.sgm"]=1.114
+                 ["newstest2017.online-G.0.en-zh.sgm"]=1.158
+                 ["newstest2017.Oregon-State-University-S.5174.en-zh.sgm"]=5.622
+                 ["newstest2017.SogouKnowing-nmt.5131.en-zh.sgm"]=1.402
+                 ["newstest2017.uedin-nmt.5111.en-zh.sgm"]=1.334
+                 ["newstest2017.UU-HNMT.5134.en-zh.sgm"]=1.000
+                 ["newstest2017.xmunmt.5165.en-zh.sgm"]=1.366
+                  )
+
+if [ -z $SKIP_TER ]; then
+  echo "-------------------"
+  echo "Starting TER tests"
+  echo "-------------------"
+  for pair in cs-en en-cs en-de en-fi en-lv en-ru en-tr en-zh; do
+      source=$(echo $pair | cut -d- -f1)
+      target=$(echo $pair | cut -d- -f2)
+      for sgm in wmt17-submitted-data/sgm/system-outputs/newstest2017/$pair/*.sgm; do
+          name=$(basename $sgm)
+
+          if [[ ! -z $limit_test && $limit_test != $name ]]; then continue; fi
+
+          if [[ ! -v "TER[$name]" ]]; then continue ; fi  # official Tercom fails for some outputs...
+
+          sys=$(basename $sgm .sgm | perl -pe 's/newstest2017\.//')
+          txt=$(dirname $sgm | perl -pe 's/sgm/txt/')/$(basename $sgm .sgm)
+          src=wmt17-submitted-data/sgm/sources/newstest2017-$source$target-src.$source.sgm
+          ref=wmt17-submitted-data/sgm/references/newstest2017-$source$target-ref.$target.sgm
+
+          score=$(cat $txt | ${CMD} -w 3 -t wmt17 -l $source-$target -b --metrics ter)
+
+          # rescale to 0-1
+          expected_score="${TER[$name]}"
+
+          echo "import sys; sys.exit(1 if abs(${score}-${expected_score}) > 0.01 else 0)" | python
+
+          if [[ $? -eq 1 ]]; then
+              echo "FAILED test $pair/$sys (wanted $expected_score got $score)"
+              exit 1
+          fi
+          echo "Passed $source-$target $sys tercom: $expected_score sacreTER: $score"
+
+          let i++
+      done
+  done
+fi
 
 #############
 # Mecab tests

--- a/test/test_ter.py
+++ b/test/test_ter.py
@@ -6,10 +6,10 @@ from argparse import Namespace
 EPSILON = 1e-3
 
 test_cases = [
-    (['aaaa bbbb cccc dddd'], ['aaaa bbbb cccc dddd'], 0),
-    (['dddd eeee ffff'], ['aaaa bbbb cccc'], 1),
-    ([''], [''], 1),
-    (['d e f g h a b c'], ['a b c d e f g h'], 1/8),
+    (['aaaa bbbb cccc dddd'], ['aaaa bbbb cccc dddd'], 0),  # perfect match
+    (['dddd eeee ffff'], ['aaaa bbbb cccc'], 1),  # no overlap
+    ([''], [''], 1),  # corner case, empty strings
+    (['d e f g h a b c'], ['a b c d e f g h'], 1/8),  # a single shift fixes MT
     (
         [
             'wählen Sie " Bild neu berechnen , " um beim Ändern der Bildgröße Pixel hinzuzufügen oder zu entfernen , damit das Bild ungefähr dieselbe Größe aufweist wie die andere Größe .',
@@ -25,7 +25,7 @@ test_cases = [
             'Sie können beispielsweise ein Dokument erstellen , das ein Auto enthalt , das sich über die Bühne bewegt .',
             'wählen Sie im Dialogfeld " Neu aus Vorlage " eine Vorlage aus und klicken Sie auf " Neu . "',
         ],
-        0.136
+        0.136  # realistic example from WMT dev data (2019)
     ),
 ]
 

--- a/test/test_ter.py
+++ b/test/test_ter.py
@@ -1,0 +1,38 @@
+import pytest
+import sacrebleu
+
+from argparse import Namespace
+
+EPSILON = 1e-3
+
+test_cases = [
+    (['aaaa bbbb cccc dddd'], ['aaaa bbbb cccc dddd'], 0),
+    (['dddd eeee ffff'], ['aaaa bbbb cccc'], 1),
+    ([''], [''], 1),
+    (['d e f g h a b c'], ['a b c d e f g h'], 1/8),
+    (
+        [
+            'wählen Sie " Bild neu berechnen , " um beim Ändern der Bildgröße Pixel hinzuzufügen oder zu entfernen , damit das Bild ungefähr dieselbe Größe aufweist wie die andere Größe .',
+            'wenn Sie alle Aufgaben im aktuellen Dokument aktualisieren möchten , wählen Sie im Menü des Aufgabenbedienfelds die Option " Alle Aufgaben aktualisieren . "',
+            'klicken Sie auf der Registerkarte " Optionen " auf die Schaltfläche " Benutzerdefiniert " und geben Sie Werte für " Fehlerkorrektur-Level " und " Y / X-Verhältnis " ein .',
+            'Sie können beispielsweise ein Dokument erstellen , das ein Auto über die Bühne enthält .',
+            'wählen Sie im Dialogfeld " Neu aus Vorlage " eine Vorlage aus und klicken Sie auf " Neu . "',
+        ],
+        [
+            'wählen Sie " Bild neu berechnen , " um beim Ändern der Bildgröße Pixel hinzuzufügen oder zu entfernen , damit die Darstellung des Bildes in einer anderen Größe beibehalten wird .',
+            'wenn Sie alle Aufgaben im aktuellen Dokument aktualisieren möchten , wählen Sie im Menü des Aufgabenbedienfelds die Option " Alle Aufgaben aktualisieren . "',
+            'klicken Sie auf der Registerkarte " Optionen " auf die Schaltfläche " Benutzerdefiniert " und geben Sie für " Fehlerkorrektur-Level " und " Y / X-Verhältnis " niedrigere Werte ein .',
+            'Sie können beispielsweise ein Dokument erstellen , das ein Auto enthalt , das sich über die Bühne bewegt .',
+            'wählen Sie im Dialogfeld " Neu aus Vorlage " eine Vorlage aus und klicken Sie auf " Neu . "',
+        ],
+        0.136
+    ),
+]
+
+
+@pytest.mark.parametrize("hypotheses, references, expected_score", test_cases)
+def test_ter(hypotheses, references, expected_score):
+    args = Namespace(tokenize=sacrebleu.DEFAULT_TOKENIZER)
+    metric = sacrebleu.metrics.TER(args)
+    score = metric.corpus_score(hypotheses, [references]).score
+    assert abs(score - expected_score) < EPSILON

--- a/test/test_tokenizer_ter.py
+++ b/test/test_tokenizer_ter.py
@@ -1,0 +1,51 @@
+import pytest
+
+from sacrebleu.tokenizers.tokenizer_ter import TercomTokenizer
+
+
+test_cases_default = [
+    ("a b c d", "a b c d"),
+    ("", ""),
+    ("a b c d.", "a b c d."),
+    ("A B C D.", "a b c d."),
+]
+
+test_cases_no_punct = [
+    ("a b c d.", "a b c d"),
+    ("A ; B ) C : D.", "a b c d"),
+]
+
+test_cases_norm = [
+    ("a b (c) d.", "a b ( c ) d"),
+    ("Jim's car.", "Jim 's car ."),
+    ("4.2", "4.2"),
+]
+
+test_cases_asian = [
+    ("美众院公布对特", "美 众 院 公 布 对 特"),  # Chinese
+    ("りの拳銃を持", "りの 拳 銃 を 持"),  # Japanese, first two letters are Hiragana
+]
+
+
+@pytest.mark.parametrize("input, expected", test_cases_default)
+def test_ter_tokenizer_default(input, expected):
+    tokenizer = TercomTokenizer()
+    assert tokenizer(input) == expected
+
+
+@pytest.mark.parametrize("input, expected", test_cases_no_punct)
+def test_ter_tokenizer_default(input, expected):
+    tokenizer = TercomTokenizer(no_punct=True)
+    assert tokenizer(input) == expected
+
+
+@pytest.mark.parametrize("input, expected", test_cases_norm)
+def test_ter_tokenizer_default(input, expected):
+    tokenizer = TercomTokenizer(normalized=True)
+    assert tokenizer(input) == expected
+
+
+@pytest.mark.parametrize("input, expected", test_cases_asian)
+def test_ter_tokenizer_default(input, expected):
+    tokenizer = TercomTokenizer(normalized=True, asian_support=True)
+    assert tokenizer(input) == expected


### PR DESCRIPTION
Hi @mjpost , please check out this work-in-progress version of TER in sacrebleu. Better late than never I guess :slightly_smiling_face: 

I think the core is basically there and it works but I'm not sure about some issues.

For instance, which parameters to expose in the CLI, and how to handle tokenization (TER has its own tokenizer which I re-implemented but we should probably allow users to switch to a different one -- for now I simply always use the TER tokenizer).

Also, I haven't given much thought to the signatures.

I think tests cover the metric pretty well. I'm planning to add tests of the TER tokenizer next week.

I'll also need to discuss with Memsource colleagues what license header to add to the new files.

EDIT: To justify the complex code: existing implementations of TER in Python, while simpler (such as `pyter`), do not produce results consistent with Tercom and can be very slow for some inputs. There are many small design decisions in the original Tercom implementation, some of them are arbitrary, and these have to be taken into account. Also, some additional optimization was required to make the code reasonably fast.