### PR TITLE
chrf: assert if refs are not in a list (#121)

### DIFF
--- a/sacrebleu/metrics/bleu.py
+++ b/sacrebleu/metrics/bleu.py
@@ -224,7 +224,8 @@ class BLEU:
         :param use_effective_order: Account for references that are shorter than the largest n-gram.
         :return: a `BLEUScore` object containing everything you'd want
         """
-        assert not isinstance(references, str), "sentence_score needs a list of references, not a single string"
+        assert not isinstance(references, str), \
+            "sentence_score needs a list of references, not a single string"
         return self.corpus_score(hypothesis, [[ref] for ref in references],
                                  use_effective_order=use_effective_order)
 

--- a/sacrebleu/metrics/chrf.py
+++ b/sacrebleu/metrics/chrf.py
@@ -130,6 +130,8 @@ class CHRF:
         :param references: Reference string(s).
         :return: Chrf score.
         """
+        assert not isinstance(references, str), \
+            "sentence_score needs a list of references, not a single string"
         stats = self.get_sentence_statistics(hypothesis, references)
         return self.compute_chrf(stats, self.order, self.beta)
 

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ setup(
     # dependencies). You can install these using the following syntax,
     # for example:
     # $ pip install -e .[dev,test]
-    extras_require = {'ja': ['mecab-python3>=1.0,<2.0', 'ipadic>=1.0,<2.0'] },
+    extras_require = {'ja': ['mecab-python3==1.0.3', 'ipadic>=1.0,<2.0'] },
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow


### PR DESCRIPTION
Bail out if references are not given in a list, for `chrf.sentence_score()` method.