### PR TITLE
adds tokenizer option to remove punctuation (except apostrophes)

### DIFF
--- a/sacrebleu/dataset.py
+++ b/sacrebleu/dataset.py
@@ -22,6 +22,42 @@
 # Many of these are *.sgm files, which are processed to produced plain text that can be used by this script.
 # The canonical location of unpacked, processed data is $SACREBLEU_DIR/$TEST/$SOURCE-$TARGET.{$SOURCE,$TARGET}
 DATASETS = {
+    "mtedx/valid": {
+        "data": ['https://raw.githubusercontent.com/esalesky/mtedx-eval/main/valid.tar.gz'],
+        "description": 'mTEDx evaluation data, valid',
+        "md5": ['866e44c55657c6c485ef96a244c0fe07'],
+        "el-en": ['valid/mtedx-valid-elen.el','valid/mtedx-valid-elen.en'],
+        "es-en": ['valid/mtedx-valid-esen.es','valid/mtedx-valid-esen.en'],
+        "es-fr": ['valid/mtedx-valid-esfr.es','valid/mtedx-valid-esfr.fr'],
+        "es-it": ['valid/mtedx-valid-esit.es','valid/mtedx-valid-esit.it'],
+        "es-pt": ['valid/mtedx-valid-espt.es','valid/mtedx-valid-espt.pt'],
+        "fr-en": ['valid/mtedx-valid-fren.fr','valid/mtedx-valid-fren.en'],
+        "fr-es": ['valid/mtedx-valid-fres.fr','valid/mtedx-valid-fres.es'],
+        "fr-pt": ['valid/mtedx-valid-frpt.fr','valid/mtedx-valid-frpt.pt'],
+        "it-en": ['valid/mtedx-valid-iten.it','valid/mtedx-valid-iten.en'],
+        "it-es": ['valid/mtedx-valid-ites.it','valid/mtedx-valid-ites.es'],
+        "pt-en": ['valid/mtedx-valid-pten.pt','valid/mtedx-valid-pten.en'],
+        "pt-es": ['valid/mtedx-valid-ptes.pt','valid/mtedx-valid-ptes.es'],
+        "ru-en": ['valid/mtedx-valid-ruen.ru','valid/mtedx-valid-ruen.en']
+    },
+    "mtedx/test": {
+        "data": ['https://raw.githubusercontent.com/esalesky/mtedx-eval/main/test.tar.gz'],
+        "description": 'mTEDx evaluation data, test',
+        "md5": ['ac79c5a5ab1b615eecd6dfbc163c0588'],
+        "el-en": ['test/mtedx-test-elen.el','test/mtedx-test-elen.en'],
+        "es-en": ['test/mtedx-test-esen.es','test/mtedx-test-esen.en'],
+        "es-fr": ['test/mtedx-test-esfr.es','test/mtedx-test-esfr.fr'],
+        "es-it": ['test/mtedx-test-esit.es','test/mtedx-test-esit.it'],
+        "es-pt": ['test/mtedx-test-espt.es','test/mtedx-test-espt.pt'],
+        "fr-en": ['test/mtedx-test-fren.fr','test/mtedx-test-fren.en'],
+        "fr-es": ['test/mtedx-test-fres.fr','test/mtedx-test-fres.es'],
+        "fr-pt": ['test/mtedx-test-frpt.fr','test/mtedx-test-frpt.pt'],
+        "it-en": ['test/mtedx-test-iten.it','test/mtedx-test-iten.en'],
+        "it-es": ['test/mtedx-test-ites.it','test/mtedx-test-ites.es'],
+        "pt-en": ['test/mtedx-test-pten.pt','test/mtedx-test-pten.en'],
+        "pt-es": ['test/mtedx-test-ptes.pt','test/mtedx-test-ptes.es'],
+        "ru-en": ['test/mtedx-test-ruen.ru','test/mtedx-test-ruen.en']
+    },
     "wmt20/robust/set1": {
         "data": ["http://data.statmt.org/wmt20/robustness-task/robustness20-3-sets.zip"],
         'description': "WMT20 robustness task, set 1",


### PR DESCRIPTION
Adds a tokenizer to remove punctuation (except apostrophes). This is to enable sacrebleu to be used for ASR corpora which have been translated (specifically Fisher Spanish--English) where the convention is to compute BLEU on lowercased, no-punct-except-apostrophes text (for better or for worse)