### PR TITLE
Allow variable number of references for BLEU via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     to make two methods behave the same.
   - Add smoothing value to BLEU signature (#98)
   - dataset: Fix IWSLT links (#128)
+  - Allow variable number of references for BLEU (only via API) (#130)
 
 - 1.4.14 (2020-09-13)
   - Added character-based tokenization (`-tok char`).

--- a/sacrebleu/metrics/bleu.py
+++ b/sacrebleu/metrics/bleu.py
@@ -281,7 +281,7 @@ class BLEU:
         fhs = [sys_stream] + ref_streams
         for lines in zip(*fhs):
             # remove undefined references (i.e. we have fewer references for this particular sentence)
-            lines = [x for x in lines if x is not None]
+            lines = [x for x in lines if x is not None and x != ""]
             if len(lines) < 2:  # we need at least system + 1 defined reference
                 raise EOFError("No valid references for a sentence!")
 


### PR DESCRIPTION
This allows BLEU to use a variable number of references (different number of references for each sentence) if called via the API (see #130). If a sentence has fewer than the maximum number of references, `None` should used to fill remaining reference streams.
