### PR TITLE
MT evaluation as a multi-class classifier: Macro and Micro averaged F-meaures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ data/
 build
 dist
 __pycache__
+
+.sacrebleu
+.idea

--- a/README.md
+++ b/README.md
@@ -130,3 +130,17 @@ If you use SacreBLEU, please cite the following:
   pages = "186--191",
 }
 ```
+
+----
+# SacreBLEU Extended
+
+SacreBLEU, in its recent versions, has been extended to include additional evaluation metrics:
+
+* ChrF : https://www.aclweb.org/anthology/W16-2341/ 
+* TER :  https://github.com/jhclark/tercom
+* MacroF and MicroF : (TODO: update link)  
+
+
+Example: 
+
+    sacrebleu REF.txt -m bleu chrf ter macrof microf < HYP.detok.txt   

--- a/sacrebleu/__main__.py
+++ b/sacrebleu/__main__.py
@@ -21,7 +21,7 @@ It also knows all the standard test sets and handles downloading, processing, an
 
 See the [README.md] file for more information.
 """
-from  .sacrebleu import main
+from .sacrebleu import main
 
 if __name__ == '__main__':
     main()

--- a/sacrebleu/metrics/__init__.py
+++ b/sacrebleu/metrics/__init__.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 
+from functools import partial
+
 from .bleu import BLEU, BLEUScore
 from .chrf import CHRF, CHRFScore
+from .clseval import AVG_TYPES, DEF_F_BETA, DEF_AVERAGE, DEF_SMOOTH_VAL
+from .clseval import ClassifierEval, MultiClassMeasure
 from .ter import TER, TERScore
 
 METRICS = {
     'bleu': BLEU,
     'chrf': CHRF,
     'ter': TER,
+    'macrof': partial(ClassifierEval, average='macro', smooth_method='add-k', max_order=1),
+    'microf': partial(ClassifierEval, average='micro', smooth_method='add-k', max_order=1)
 }

--- a/sacrebleu/metrics/base.py
+++ b/sacrebleu/metrics/base.py
@@ -4,6 +4,9 @@ from .. import __version__
 
 class BaseScore:
     """A base score class to derive from."""
+
+    __slots__ = ('score',)
+
     def __init__(self, score):
         self.score = score
 
@@ -56,3 +59,4 @@ class Signature:
 
     def __repr__(self):
         return self.__str__()
+

--- a/sacrebleu/metrics/bleu.py
+++ b/sacrebleu/metrics/bleu.py
@@ -122,7 +122,7 @@ class BLEU:
         return ngrams
 
     @staticmethod
-    def reference_stats(refs, output_len):
+    def reference_stats(refs, output_len, max_order=NGRAM_ORDER):
         """Extracts reference statistics for a given segment.
 
         :param refs: A list of segment tokens.
@@ -145,7 +145,7 @@ class BLEU:
                 if reflen < closest_len:
                     closest_len = reflen
 
-            ngrams_ref = BLEU.extract_ngrams(ref)
+            ngrams_ref = BLEU.extract_ngrams(ref, max_order=max_order)
             for ngram in ngrams_ref.keys():
                 ngrams[ngram] = max(ngrams[ngram], ngrams_ref[ngram])
 

--- a/sacrebleu/metrics/clseval.py
+++ b/sacrebleu/metrics/clseval.py
@@ -1,0 +1,319 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-
+
+"""
+This work is based on:
+  Macro-average: Rare Types Are Important Too
+    Gowda et al (NAACL 2021)
+    TODO: update the link to paper
+"""
+
+import copy
+import logging as log
+from argparse import Namespace
+from itertools import zip_longest
+from pathlib import Path
+from typing import Union, Iterable, List, Dict, Tuple
+
+from .base import BaseScore
+from .bleu import BLEU, BLEUSignature
+
+DEF_F_BETA = 1
+DEF_AVERAGE = 'macro'
+DEF_SMOOTH_VAL = 1
+
+
+class ClassMeasure(BaseScore):
+    __slots__ = 'preds', 'refs', 'correct', 'measure_name', 'name'
+
+    def __init__(self, name, preds=0, refs=0, correct=0):
+        self.preds = preds
+        self.refs = refs
+        self.correct = correct
+        self.name = name
+        super().__init__(score=self.f1)
+
+    @property
+    def precision(self) -> float:
+        assert 0 <= self.correct <= self.preds
+        # Note: zero correct while zero are predicted is perfect precision
+        return (self.correct / self.preds) if self.preds > 0 else 1
+
+    @property
+    def recall(self) -> float:
+        assert 0 <= self.correct <= self.refs
+        # Note: zero correct while zero reference is perfect recall
+        return (self.correct / self.refs) if self.refs > 0 else 1
+
+    def f_measure(self, beta: float = 1) -> float:
+        denr = beta ** 2 * self.precision + self.recall
+        if denr == 0:
+            # Note: either zero precision or zero recall leads to zero f1
+            return 0
+        return (1 + beta ** 2) * self.precision * self.recall / denr
+
+    @property
+    def f1(self) -> float:
+        return self.f_measure(beta=1)
+
+    def measure(self, measure_name):
+        cache = dict(f1=self.f1, precision=self.precision, recall=self.recall)
+        if measure_name in cache:
+            return cache[measure_name]
+        elif measure_name.startswith('f'):
+            beta = float(measure_name[1:])
+            return self.f_measure(beta=beta)
+        else:
+            raise Exception(f'Unknown measure name : {measure_name}')
+
+    def __str__(self):
+        return f'ClassMeasure[{self.name}, pred/cor/ref={self.preds}/{self.correct}/{self.refs} ' \
+               f'P/R/F1={self.precision:g}/{self.recall:g}/{self.f1:g}]'
+
+    def format(self, width=4, score_only=False, signature='') -> str:
+        if score_only:
+            return f'{self.score:.{width}f}'
+        prefix = self.name
+        if signature:
+            prefix += f'+{signature}'
+        return f'{prefix} {self.score:.{width}f}'
+
+AVG_TYPES = {
+    'macro': lambda _: 1,
+    'micro': lambda f: f,  # term frequency
+    #    'micro_sqrt': lambda f: math.sqrt(f),
+    #    'micro_log': lambda f: 1 + math.log(f),
+    #    'micro_inv': lambda f: 1 / f,  # inverted frequency
+}
+
+
+class MultiClassMeasure(BaseScore):
+    """
+    Consolidates multiple ClassMeasure s into single measure
+    """
+
+    def __init__(self, classes: List[ClassMeasure], average='macro', f_beta=1,
+                 smooth_value=0, percent=True, signature='', hyp_len=None, ref_len=None):
+        self.smooth_value = smooth_value
+        self.signature = signature
+        self.classes = classes
+        self.percent = percent
+
+        wt_func = AVG_TYPES[average]
+        wt_scores = [(m.f_measure(beta=f_beta), wt_func(m.refs + smooth_value))
+                     for m in classes]
+        f_score = sum(score * w for score, w in wt_scores) / sum(w for score, w in wt_scores)
+        scaler = 100 if percent else 1
+        f_score *= scaler
+        name = 'F{beta:g}'.format(beta=f_beta)
+        if average in ('macro', 'micro'):
+            name = average.title() + name  # eg MacroF1 MicroF1 MacroF2 ...
+        self.name = name
+        super().__init__(score=f_score)
+
+        # extra info
+        self.hyp_len = hyp_len
+        self.ref_len = ref_len
+        self.avgs = {}
+        for n in ('precision', 'recall'):
+            wt_scores = [(m.measure(measure_name=n.lower()), wt_func(m.refs + smooth_value))
+                         for m in classes]
+            norm = sum(w for score, w in wt_scores)
+            self.avgs[n] = scaler * sum(score * w for score, w in wt_scores) / norm
+
+    def __str__(self):
+        return self.format()
+
+    def format(self, width=2, score_only=False, signature='') -> str:
+        if score_only:
+            return '{score:.{width}f}'.format(score=self.score, width=width)
+        prefix = self.name
+        if signature:
+            prefix += '+' + str(signature)
+        line = '{prefix} {score:.{width}f}  Precision = {p:.{width}f} Recall = {r:.{width}f}'.format(
+            prefix=prefix, score=self.score, width=width, p=self.avgs['precision'],
+            r=self.avgs['recall'])
+
+        if self.ref_len:
+            line += ' len_ratio = {ratio:.3f} hyp_len = {hyp_len} ref_len = {ref_len}'.format(
+                ratio=self.hyp_len / self.ref_len, hyp_len=self.hyp_len, ref_len=self.ref_len)
+        return line
+
+    def write_report(self, path):
+        if isinstance(path, str):
+            path = Path(path)
+        scaler, width = 1, 4
+        if self.percent:
+            scaler, width = 100, 2
+
+        # sort by ascending of ngram, descending of ref_freq, descending of hyp_freq
+        class_stats: List[ClassMeasure] = sorted(self.classes, reverse=True,
+                                                 key=lambda s: (s.refs, s.preds))
+        delim = '\t'
+        ljust = 15
+
+        def format_class_stat(class_: ClassMeasure):
+            row = [" ".join(class_.name).ljust(ljust), f"{class_.score * scaler:.{width}f}"]
+            row += [str(x) for x in [class_.refs, class_.preds, class_.correct]]
+            row += [f'{class_.measure(measure_name=x) * scaler:.{width}f}'
+                    for x in 'f1 precision recall'.split()]
+            return delim.join(row)
+
+        with path.open('w', encoding='utf-8', errors='ignore') as out:
+            header = ['Type'.ljust(ljust), 'Score', 'Refs', 'Preds', 'Match', 'F1', 'Precisn',
+                      'Recall']
+            out.write(self.format(width=width) + '\n')
+            out.write(str(self.signature) + '\n')
+            out.write('\n----\n')
+            out.write(delim.join(header) + '\n')
+            for cs in class_stats:
+                out.write(format_class_stat(cs) + '\n')
+
+
+def _prepare_lines(sys_stream, ref_streams, lowercase, tokenizer, force):
+    # Add some robustness to the input arguments
+    if isinstance(sys_stream, str):
+        sys_stream = [sys_stream]
+    if isinstance(ref_streams, str):
+        ref_streams = [[ref_streams]]
+    tokenized_count = 0  # look for already-tokenized sentences
+    fhs = [sys_stream] + ref_streams
+    for lines in zip_longest(*fhs):
+        if None in lines:
+            raise EOFError("Source and reference streams have different lengths!")
+
+        if lowercase:
+            lines = [x.lower() for x in lines]
+
+        if not (force or tokenizer.signature() == 'none') and lines[0].rstrip().endswith(' .'):
+            tokenized_count += 1
+            if tokenized_count == 100:
+                msg = """"That's 100 lines that end in a tokenized period (' .')
+                It looks like you forgot to detokenize your test data, which may hurt your score.
+                If you insist your data is detokenized, or don't care, you can suppress this message with '--force'."""
+                log.warning(msg)
+        lines = [tokenizer(x.rstrip()) for x in lines]
+        yield lines
+
+
+class ClassifierEvalSignature(BLEUSignature):
+
+    def __init__(self, args):
+        super().__init__(args)
+        # Abbreviations for the signature
+
+        self._abbr.update({
+            'average': 'a',
+            'ngram': 'ng'})
+
+        self.info.update({
+            'average': args.average,
+            'ngram': args.max_order,
+            'smooth': '{meth}.{val}'.format(val=args.smooth_value, meth=args.smooth_method)
+        })
+        # smoothing does not apply to macro average
+        if args.average == 'macro':
+            del self.info['smooth']
+        if args.average in ('macro', 'micro'):
+            # these are common and hence part of name e.g. MacroF, MicroF
+            del self.info['average']
+
+
+class ClassifierEval(BLEU):
+    BETA = DEF_F_BETA
+
+    def __init__(self, args, **override_args):
+
+        if isinstance(args, dict):
+            args = Namespace(**args)
+        else:
+            args = copy.deepcopy(args)
+
+        # overwrite args, they are used by signature
+        override_args = override_args or {}
+        for key, val in override_args.items():
+            setattr(args, key, val)
+        args.smooth_value = args.smooth_value or DEF_SMOOTH_VAL
+
+        super().__init__(args)
+        self.signature = ClassifierEvalSignature(args)
+        self.max_order = args.max_order
+        assert self.max_order == 1  # only unigrams are used for now; n > 1 is for future work
+        self.smooth_value = args.smooth_value
+        self.f_beta = override_args.get('f_beta', args.f_beta)
+        assert args.average in AVG_TYPES, f'{args.average} is invalid; use:{list(AVG_TYPES.keys())}'
+        self.average = args.average
+        self.weight_func = AVG_TYPES[args.average]
+
+    def corpus_score(self, sys_stream: Union[str, Iterable[str]],
+                     ref_streams: Union[str, List[Iterable[str]]],
+                     use_effective_order: bool = False) \
+            -> MultiClassMeasure:
+        """Produces Multi-class evaluation score from a source against one or more references.
+
+        :param sys_stream: The system stream (a sequence of segments)
+        :param ref_streams: A list of one or more reference streams (each a sequence of segments)
+        :return: a MultiClassMeasure object containing everything you'd want
+        """
+        lines = _prepare_lines(sys_stream, ref_streams, self.lc, self.tokenizer, self.force)
+        gram_stats, ref_len, hyp_len = self.n_gram_performance(lines, self.max_order)
+
+        class_measures: List[ClassMeasure] = list(gram_stats.values())
+        max_oder = 0
+        for class_meas in class_measures:
+            assert isinstance(class_meas.name, str)
+            class_meas.name = tuple(
+                class_meas.name.split())  # convert space separated ngram string to tuple
+            max_oder = max(max_oder, len(class_meas.name))
+        assert max_oder == 1  # only unigrams for now
+
+        score = MultiClassMeasure(classes=class_measures, f_beta=self.f_beta, percent=True,
+                                  average=self.average, smooth_value=self.smooth_value,
+                                  signature=str(self.signature), hyp_len=hyp_len, ref_len=ref_len)
+        return score
+
+    @classmethod
+    def n_gram_performance(cls, lines: Iterable[List[str]], max_order: int) \
+            -> Tuple[Dict[str, ClassMeasure], int, int]:
+        """
+        Gets n-gram performance by comparing system output against 1 or more references
+        :param lines:  iterator of [output, ref1 ...] where output and ref1,... are tokenized lines
+        :param max_order: maximum n_grams order
+        :return: gram_performance, ref_len, sys_len
+        """
+        assert max_order >= 1
+        sys_len, ref_len = 0, 0
+        gram_stats = {}
+        for output, *refs in lines:
+            out_toks = output.split()
+            ref_ngrams, closest_diff, closest_len = cls.reference_stats(
+                refs=refs, output_len=len(out_toks), max_order=max_order)
+            sys_len += len(out_toks)
+            ref_len += closest_len
+
+            sys_ngrams = cls.extract_ngrams(output, max_order=max_order)
+            for ngram in sys_ngrams.keys():  # n-grams that are recalled by sys
+                if ngram not in gram_stats:
+                    gram_stats[ngram] = ClassMeasure(name=ngram)
+                gram_stats[ngram].preds += sys_ngrams[ngram]
+                gram_stats[ngram].correct += min(sys_ngrams[ngram], ref_ngrams.get(ngram, 0))
+                gram_stats[ngram].refs += ref_ngrams.get(ngram, 0)
+
+            for ngram in ref_ngrams.keys() - sys_ngrams.keys():  # n-grams that are not recalled by sys
+                if ngram not in gram_stats:
+                    gram_stats[ngram] = ClassMeasure(name=ngram)
+                gram_stats[ngram].refs += ref_ngrams[ngram]
+                # .cand and .match are zero by default
+        return gram_stats, ref_len, sys_len

--- a/sacrebleu/metrics/clseval.py
+++ b/sacrebleu/metrics/clseval.py
@@ -76,19 +76,15 @@ class ClassMeasure(BaseScore):
             beta = float(measure_name[1:])
             return self.f_measure(beta=beta)
         else:
-            raise Exception(f'Unknown measure name : {measure_name}')
-
-    def __str__(self):
-        return f'ClassMeasure[{self.name}, pred/cor/ref={self.preds}/{self.correct}/{self.refs} ' \
-               f'P/R/F1={self.precision:g}/{self.recall:g}/{self.f1:g}]'
+            raise Exception('Unknown measure name : {m}'.format(m=measure_name))
 
     def format(self, width=4, score_only=False, signature='') -> str:
         if score_only:
-            return f'{self.score:.{width}f}'
+            return '{score:.{width}f}'.format(score=self.score, width=width)
         prefix = self.name
         if signature:
-            prefix += f'+{signature}'
-        return f'{prefix} {self.score:.{width}f}'
+            prefix += str(signature)
+        return '{prefix} {score:.{width}f}'.format(prefix=prefix, score=self.score, width=width)
 
 AVG_TYPES = {
     'macro': lambda _: 1,
@@ -167,7 +163,8 @@ class MultiClassMeasure(BaseScore):
         def format_class_stat(class_: ClassMeasure):
             row = [" ".join(class_.name).ljust(ljust), f"{class_.score * scaler:.{width}f}"]
             row += [str(x) for x in [class_.refs, class_.preds, class_.correct]]
-            row += [f'{class_.measure(measure_name=x) * scaler:.{width}f}'
+            row += ['{score:.{width}f}'.format(score=class_.measure(measure_name=x) * scaler,
+                                               width=width)
                     for x in 'f1 precision recall'.split()]
             return delim.join(row)
 
@@ -253,7 +250,8 @@ class ClassifierEval(BLEU):
         assert self.max_order == 1  # only unigrams are used for now; n > 1 is for future work
         self.smooth_value = args.smooth_value
         self.f_beta = override_args.get('f_beta', args.f_beta)
-        assert args.average in AVG_TYPES, f'{args.average} is invalid; use:{list(AVG_TYPES.keys())}'
+        assert args.average in AVG_TYPES, '{a} is invalid; use:{l}'.format(
+            a=args.average, l=list(AVG_TYPES.keys()))
         self.average = args.average
         self.weight_func = AVG_TYPES[args.average]
 

--- a/sacrebleu/sacrebleu.py
+++ b/sacrebleu/sacrebleu.py
@@ -37,7 +37,7 @@ if __package__ is None and __name__ == '__main__':
 
 from .tokenizers import TOKENIZERS, DEFAULT_TOKENIZER
 from .dataset import DATASETS, DOMAINS, COUNTRIES, SUBSETS
-from .metrics import METRICS
+from .metrics import METRICS, DEF_F_BETA
 
 from .utils import smart_open, filter_subset, get_available_origlangs, SACREBLEU_DIR
 from .utils import get_langpairs_for_testset, get_available_testsets
@@ -63,6 +63,7 @@ def parse_args():
         description='sacreBLEU: Hassle-free computation of shareable BLEU scores.\n'
                     'Quick usage: score your detokenized output against WMT\'14 EN-DE:\n'
                     '    cat output.detok.de | sacrebleu -t wmt14 -l en-de',
+        epilog=f'\n\033[93m You are using v{VERSION} from {__file__}\033[0m',
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     arg_parser.add_argument('--citation', '--cite', default=False, action='store_true',
@@ -94,7 +95,8 @@ def parse_args():
 
     # Metric selection
     arg_parser.add_argument('--metrics', '-m', choices=METRICS.keys(), nargs='+', default=['bleu'],
-                            help='metrics to compute (default: bleu)')
+                            metavar='METRIC',
+                            help=f'Metrics to compute. Known metrics: {list(METRICS)} (default: bleu)')
     arg_parser.add_argument('--sentence-level', '-sl', action='store_true', help='Output metric on each sentence.')
 
     # BLEU-related arguments
@@ -110,12 +112,22 @@ def parse_args():
                             help='insist that your tokenized input is actually detokenized')
 
     # ChrF-related arguments
-    arg_parser.add_argument('--chrf-order', type=int, default=METRICS['chrf'].ORDER,
+    chrf_p = arg_parser.add_argument_group(title='CHRF args')
+    chrf_p.add_argument('--chrf-order', type=int, default=METRICS['chrf'].ORDER,
                             help='chrf character order (default: %(default)s)')
-    arg_parser.add_argument('--chrf-beta', type=int, default=METRICS['chrf'].BETA,
+    chrf_p.add_argument('--chrf-beta', type=int, default=METRICS['chrf'].BETA,
                             help='chrf BETA parameter (default: %(default)s)')
-    arg_parser.add_argument('--chrf-whitespace', action='store_true', default=False,
+    chrf_p.add_argument('--chrf-whitespace', action='store_true', default=False,
                             help='include whitespace in chrF calculation (default: %(default)s)')
+
+    # Classifier eval related args
+    clseval_p = arg_parser.add_argument_group(title="Args specifically for macrof and microf")
+    clseval_p.add_argument('-fb', '--f-beta', metavar='β', type=float,
+                             default=DEF_F_BETA,
+                             help='F-measure β param that weighs recall (default: %(default)s)')
+    clseval_p.add_argument('--report',  type=str,
+                           help='Path to write detailed performance report of individual classes.'
+                                ' (optional)')
 
     # Reporting related arguments
     arg_parser.add_argument('--quiet', '-q', default=False, action='store_true',
@@ -161,6 +173,10 @@ def main():
     if args.sentence_level and len(args.metrics) > 1:
         sacrelogger.error('Only one metric can be used with Sentence-level reporting.')
         sys.exit(1)
+
+    if args.report and len(args.metrics) > 1:
+        sacrelogger.error('Only one metric can be used with --report argument.')
+        sys.exit(2)
 
     if args.citation:
         if not args.test_set:
@@ -302,7 +318,7 @@ def main():
         sys.exit(0)
 
     # Else, handle system level
-    for metric in metrics:
+    for metric_name, metric in zip(args.metrics, metrics):
         try:
             score = metric.corpus_score(system, refs)
         except EOFError:
@@ -318,6 +334,9 @@ def main():
             sys.exit(1)
         else:
             print(score.format(args.width, args.score_only, metric.signature))
+            if args.report and hasattr(score, 'write_report'):
+                score.write_report(args.report)
+
 
     if args.detail:
         width = args.width

--- a/sacrebleu/sacrebleu.py
+++ b/sacrebleu/sacrebleu.py
@@ -63,7 +63,7 @@ def parse_args():
         description='sacreBLEU: Hassle-free computation of shareable BLEU scores.\n'
                     'Quick usage: score your detokenized output against WMT\'14 EN-DE:\n'
                     '    cat output.detok.de | sacrebleu -t wmt14 -l en-de',
-        epilog=f'\n\033[93m You are using v{VERSION} from {__file__}\033[0m',
+        epilog='\n\033[93m You are using v{v} from {f}\033[0m'.format(v=VERSION, f=__file__),
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     arg_parser.add_argument('--citation', '--cite', default=False, action='store_true',
@@ -95,8 +95,7 @@ def parse_args():
 
     # Metric selection
     arg_parser.add_argument('--metrics', '-m', choices=METRICS.keys(), nargs='+', default=['bleu'],
-                            metavar='METRIC',
-                            help=f'Metrics to compute. Known metrics: {list(METRICS)} (default: bleu)')
+                            metavar='METRIC', help='Metrics to compute. Known metrics: {known} (default: bleu)'.format(known=list(METRICS)))
     arg_parser.add_argument('--sentence-level', '-sl', action='store_true', help='Output metric on each sentence.')
 
     # BLEU-related arguments

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/test/test_clseval.py
+++ b/test/test_clseval.py
@@ -1,0 +1,68 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# -*- coding: utf-8 -*-
+from sacrebleu import corpus_macrof, corpus_microf
+
+EPSILON = 1e-9
+
+
+def test_clseval():
+    refs = ['the cat sat on the mat', 'ಬಾ ಬಾ ಗಿಣಿಯೇ ಬಣ್ಣದ ಗಿಣಿಯೇ ಹಣ್ಣನು ಕೊಡುವೆನು ಬಾ ಬಾ']
+    refss = [refs]
+    assert abs(corpus_macrof(refs, refss).score - 100.0) < EPSILON
+    assert abs(corpus_microf(refs, refss).score - 100.0) < EPSILON
+
+    hyps = ['cat sat on mat it', 'the ಗಿಣಿಯೇ ಬಣ್ಣದ ಹಣ್ಣನು ಕೊಡುವೆನು ಬಾ']
+    """ total classes 10 + 1 : 
+             the (2), cat (1), sat (1), on (1), mat (1), ಬಾ (4), ಗಿಣಿಯೇ (2), ಬಣ್ಣದ (1), ಹಣ್ಣನು (1),
+             ಕೊಡುವೆನು (1), it (0)         
+    """
+    # ['Type', 'Refs', 'Preds', 'Match', "Precision", 'Recall', "F1"],
+    stats = [
+        ['the',       2,      1,        0,         0,         0,     0],
+        ['cat',       1,      1,        1,         1,         1,     1],
+        ['sat',       1,      1,        1,         1,         1,     1],
+        ['on',        1,      1,        1,         1,         1,     1],
+        ['mat',       1,      1,        1,         1,         1,     1],
+        ['it',        0,      1,        0,         0,         1,     0],
+        ['ಬಾ',        4,      1,        1,         1,       .25,  2*1*.25/(1+.25)],
+        ['ಗಿಣಿಯೇ',    2,      1,        1,         1,       .50,   2*1*.50/(1+.50)],
+        ['ಬಣ್ಣದ',     1,      1,        1,          1,         1,     1],
+        ['ಹಣ್ಣನು',     1,      1,       1,          1,         1,     1],
+        ['ಕೊಡುವೆನು',   1,     1,        1,         1,          1,     1],
+    ]
+
+    smooth_value = 1   # small smoothing value
+    idx_refs, idx_f1 = 1, -1
+    macro_expected = 100 * sum(r[idx_f1] for r in stats) / len(stats)
+    # Frequencies for micro avg are always from references; so we can compare different hyps
+    norm = sum(smooth_value + r[idx_refs] for r in stats)
+    micro_expected = 100 * sum((smooth_value + r[idx_refs]) * r[idx_f1] for r in stats) / norm
+
+    assert abs(micro_expected - macro_expected) > 1000 * EPSILON  # they are different
+
+    macro_score = corpus_macrof(hyps, refss)
+    assert abs(macro_score.score - macro_expected) < EPSILON
+
+
+    micro_score = corpus_microf(hyps, refss, smooth_value=smooth_value)
+    assert abs(micro_score.score - micro_expected) < EPSILON
+
+    infinity = 1E12     # using a large smoothing_value => micro approaches macro
+    micro_score2 = corpus_microf(hyps, refss, smooth_value=infinity)
+    assert abs(micro_score2.score - macro_expected) < EPSILON  # they are same
+
+
+if __name__ == '__main__':
+    test_clseval()


### PR DESCRIPTION
This code has been used by our work "Macro-Average: Rare Types are Important Too".  ~(To-appear at NAACL2021) 
I am still working on a camera-ready version of the paper (haven't uploaded it to arxiv yet); for now, here is a summary: https://isi.edu/~tg/posts/2021/03/macroavg-rare-types-important/~ https://aclanthology.org/2021.naacl-main.90/ 

@mjpost and others managing this repo, Kindly let me know if these changes can be accepted to this repo, so I can point to this repo in my final version instead of our fork. Thanks

**How to test:**

    sacrebleu REF.txt -m macrof microf < HYP.detok.txt 


I recommend `macrof` to be used; `microf` is for comparison and also a placeholder for more complicated averaging strategies if anyone interested. 

One of my favorite features is `--report`; helps postmortem model performance to the level of each class/type; their precision, recall etc.  E.g.

    sacrebleu REF.txt -m macrof --report macrof.report.tsv  < HYP.detok.txt 
   

P.S. 
In case you are wondering, I had tried several complicated metrics, along the direction of converting BLEU (a micro-avg metric) to have macro-average. In the end, I couldn't justify the complicated metrics to be better than a simple Macro-avg F1 measure (on current WMT metrics datasets; looks like organizers are making some changes, so that's good!). So I cleaned up all the unwanted code and squashed it all into a single commit.  For now, these metrics are limiting `max_order=1` i.e. just the unigrams. 


EDIT: 
Here is a preprint from Arxiv https://arxiv.org/abs/2104.05700 