### PR TITLE
Add a Korean tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ following command instead, to perform a full installation with dependencies:
 
     pip install sacrebleu[ja]
 
+In order to install Korean tokenizer support through `pymecab-ko`, you need to run the
+following command instead, to perform a full installation with dependencies:
+
+    pip install sacrebleu[ko]
+
 # Command-line Usage
 
 You can get a list of available test sets with `sacrebleu --list`. Please see [DATASETS.md](DATASETS.md)
@@ -194,8 +199,8 @@ BLEU related arguments:
                         Smoothing method: exponential decay, floor (increment zero counts), add-k (increment num/denom by k for n>1), or none. (Default: exp)
   --smooth-value BLEU_SMOOTH_VALUE, -sv BLEU_SMOOTH_VALUE
                         The smoothing value. Only valid for floor and add-k. (Defaults: floor: 0.1, add-k: 1)
-  --tokenize {none,zh,13a,char,intl,ja-mecab}, -tok {none,zh,13a,char,intl,ja-mecab}
-                        Tokenization method to use for BLEU. If not provided, defaults to `zh` for Chinese, `ja-mecab` for Japanese and `13a` (mteval) otherwise.
+  --tokenize {none,zh,13a,char,intl,ja-mecab,ko-mecab}, -tok {none,zh,13a,char,intl,ja-mecab,ko-mecab}
+                        Tokenization method to use for BLEU. If not provided, defaults to `zh` for Chinese, `ja-mecab` for Japanese, `ko-mecab` for Korean and `13a` (mteval) otherwise.
   --lowercase, -lc      If True, enables case-insensitivity. (Default: False)
   --force               Insist that your tokenized input is actually detokenized.
 
@@ -247,11 +252,12 @@ but it expects that you pass through the entire translated test set.
    - `intl` applies international tokenization and mimics the `mteval-v14` script from Moses
    - `zh` separates out **Chinese** characters and tokenizes the non-Chinese parts using `13a` tokenizer
    - `ja-mecab` tokenizes **Japanese** inputs using the [MeCab](https://pypi.org/project/mecab-python3) morphological analyzer
+   - `ko-mecab` tokenizes **Korean** inputs using the [MeCab-ko](https://pypi.org/project/mecab-ko) morphological analyzer
    - `spm` uses the SentencePiece model built from the Flores-101 dataset (https://github.com/facebookresearch/flores#list-of-languages). Note: the canonical .spm file will be automatically fetched if not found locally.
 - You can switch tokenizers using the `--tokenize` flag of sacreBLEU. Alternatively, if you provide language-pair strings
-  using `--language-pair/-l`, `zh` and `ja-mecab` tokenizers will be used if the target language is `zh` or `ja`, respectively.
+  using `--language-pair/-l`, `zh`, `ja-mecab` and `ko-mecab` tokenizers will be used if the target language is `zh` or `ja` or `ko`, respectively.
 - **Note that** there's no automatic language detection from the hypotheses so you need to make sure that you are correctly
-  selecting the tokenizer for **Japanese** and **Chinese**.
+  selecting the tokenizer for **Japanese**, **Korean** and **Chinese**.
 
 
 Default 13a tokenizer will produce poor results for Japanese:

--- a/sacrebleu/metrics/bleu.py
+++ b/sacrebleu/metrics/bleu.py
@@ -22,6 +22,7 @@ _TOKENIZERS = {
     'intl': 'tokenizer_intl.TokenizerV14International',
     'char': 'tokenizer_char.TokenizerChar',
     'ja-mecab': 'tokenizer_ja_mecab.TokenizerJaMecab',
+    'ko-mecab': 'tokenizer_ko_mecab.TokenizerKoMecab',
     'spm': 'tokenizer_spm.TokenizerSPM',
 }
 
@@ -133,7 +134,7 @@ class BLEU(Metric):
         'exp': None,    # No value is required
     }
 
-    TOKENIZERS = ['none', 'zh', '13a', 'char', 'intl', 'ja-mecab', 'spm']
+    TOKENIZERS = ['none', 'zh', '13a', 'char', 'intl', 'ja-mecab', 'ko-mecab', 'spm']
 
     # mteval-v13a.pl tokenizer unless Chinese or Japanese is provided
     TOKENIZER_DEFAULT = '13a'
@@ -143,6 +144,7 @@ class BLEU(Metric):
     _TOKENIZER_MAP = {
         'zh': 'zh',
         'ja': 'ja-mecab',
+        'ko': 'ko-mecab',
     }
 
     _SIGNATURE_TYPE = BLEUSignature
@@ -175,7 +177,7 @@ class BLEU(Metric):
         if tokenize is None:
             best_tokenizer = self.TOKENIZER_DEFAULT
 
-            # Set `zh` or `ja-mecab` if target language is provided
+            # Set `zh` or `ja-mecab` or `ko-mecab` if target language is provided
             if self.trg_lang in self._TOKENIZER_MAP:
                 best_tokenizer = self._TOKENIZER_MAP[self.trg_lang]
         else:
@@ -186,6 +188,9 @@ class BLEU(Metric):
             if self.trg_lang == 'ja' and best_tokenizer != 'ja-mecab':
                 sacrelogger.warning(
                     "You should use the 'ja-mecab' tokenizer for Japanese.")
+            if self.trg_lang == 'ko' and best_tokenizer != 'ko-mecab':
+                sacrelogger.warning(
+                    "You should use the 'ko-mecab' tokenizer for Korean.")
 
         # Create the tokenizer
         self.tokenizer = _get_tokenizer(best_tokenizer)()

--- a/sacrebleu/sacrebleu.py
+++ b/sacrebleu/sacrebleu.py
@@ -117,7 +117,8 @@ def parse_args():
                                 f"add-k: {METRICS['BLEU'].SMOOTH_DEFAULTS['add-k']})")
     bleu_args.add_argument('--tokenize', '-tok', choices=METRICS['BLEU'].TOKENIZERS, default=None,
                            dest='bleu_tokenize',
-                           help='Tokenization method to use for BLEU. If not provided, defaults to `zh` for Chinese, `ja-mecab` for Japanese and `13a` (mteval) otherwise.')
+                           help='Tokenization method to use for BLEU. If not provided, defaults to `zh` for Chinese, '
+                                '`ja-mecab` for Japanese, `ko-mecab` for Korean and `13a` (mteval) otherwise.')
     bleu_args.add_argument('--lowercase', '-lc', dest='bleu_lowercase', action='store_true', default=False,
                            help='If True, enables case-insensitivity. (Default: %(default)s)')
     bleu_args.add_argument('--force', default=False, action='store_true',

--- a/sacrebleu/tokenizers/tokenizer_ko_mecab.py
+++ b/sacrebleu/tokenizers/tokenizer_ko_mecab.py
@@ -1,0 +1,52 @@
+from functools import lru_cache
+
+try:
+    import mecab_ko as MeCab
+    import mecab_ko_dic
+except ImportError:
+    # Don't fail until the tokenizer is actually used
+    MeCab = None
+
+from .tokenizer_base import BaseTokenizer
+
+FAIL_MESSAGE = """
+Korean tokenization requires extra dependencies, but you do not have them installed.
+Please install them like so.
+
+    pip install sacrebleu[ko]
+"""
+
+
+class TokenizerKoMecab(BaseTokenizer):
+    def __init__(self):
+        if MeCab is None:
+            raise RuntimeError(FAIL_MESSAGE)
+        self.tagger = MeCab.Tagger(mecab_ko_dic.MECAB_ARGS + " -Owakati")
+
+        # make sure the dictionary is IPA
+        d = self.tagger.dictionary_info()
+        assert d.size == 811795, \
+            "Please make sure to use the mecab-ko-dic for MeCab-ko"
+        # This asserts that no user dictionary has been loaded
+        assert d.next is None
+
+    @lru_cache(maxsize=2**16)
+    def __call__(self, line):
+        """
+        Tokenizes an Korean input line using MeCab-ko morphological analyzer.
+
+        :param line: a segment to tokenize
+        :return: the tokenized line
+        """
+        line = line.strip()
+        sentence = self.tagger.parse(line).strip()
+        return sentence
+
+    def signature(self):
+        """
+        Returns the MeCab-ko parameters.
+
+        :return: signature string
+        """
+        signature = self.tagger.version() + "-KO"
+        return 'ko-mecab-' + signature

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,8 @@ setup(
     # dependencies). You can install these using the following syntax,
     # for example:
     # $ pip install -e .[dev,test]
-    extras_require={'ja': ['mecab-python3==1.0.3', 'ipadic>=1.0,<2.0']},
+    extras_require={'ja': ['mecab-python3==1.0.3', 'ipadic>=1.0,<2.0'],
+                    'ko': ['mecab-ko==0.0.1a1', 'mecab-ko-dic>=1.0,<2.0']},
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/test.sh
+++ b/test.sh
@@ -54,6 +54,7 @@ SKIP_INITIAL=${SKIP_INITIAL:-}
 SKIP_CHRF=${SKIP_CHRF:-}
 SKIP_TER=${SKIP_TER:-}
 SKIP_MECAB=${SKIP_MECAB:-}
+SKIP_MECAB_KO=${SKIP_MECAB_KO:-}
 SKIP_MTEVAL13=${SKIP_MTEVAL13:-}
 SKIP_MTEVAL14=${SKIP_MTEVAL14:-}
 
@@ -100,6 +101,14 @@ if [[ ! -d en-ja-translation-example-master ]]; then
    echo "Downloading and unpacking English-Japanese test data..."
    wget -q https://github.com/MorinoseiMorizo/en-ja-translation-example/archive/master.zip
    unzip master.zip
+   rm master.zip
+fi
+
+if [[ ! -d en-ko-translation-example-master ]]; then
+   echo "Downloading and unpacking English-Korean test data..."
+   wget -q https://github.com/NoUnique/en-ko-translation-example/archive/master.zip
+   unzip master.zip
+   rm master.zip
 fi
 
 if [ -z $SKIP_INITIAL ]; then
@@ -459,6 +468,7 @@ declare -A MTEVAL=( ["newstest2017.PJATK.4760.cs-en.sgm"]=23.15
                     ["newstest2017.uedin-nmt.5112.zh-en.sgm"]=25.7
                     ["newstest2017.xmunmt.5160.zh-en.sgm"]=26.0
                     ["kyoto-test"]=14.48
+                    ["flores101.devtest.en-ko"]=33.18
                   )
 
 if [ -z $SKIP_MTEVAL13 ]; then
@@ -683,6 +693,37 @@ if [[ -z $SKIP_MECAB ]]; then
     source=$(echo $pair | cut -d- -f1)
     target=$(echo $pair | cut -d- -f2)
     for txt in en-ja-translation-example-master/*.hyp.$target; do
+        name=$(basename $txt .hyp.$target)
+
+        if [[ ! -z $limit_test && $limit_test != $name ]]; then continue; fi
+
+        sys=$(basename $txt .hyp.$target)
+        ref=$(dirname $txt)/$(basename $txt .hyp.$target).ref.$target
+        score=$(cat $txt | ${CMD} -w 2 -l $source-$target -b $ref)
+
+        echo "import sys; sys.exit(1 if abs($score-${MTEVAL[$name]}) > 0.01 else 0)" | python
+
+        if [[ $? -eq 1 ]]; then
+            echo "FAILED test $pair/$sys (wanted ${MTEVAL[$name]} got $score)"
+            exit 1
+        fi
+        echo "Passed $source-$target $sys mteval-v13a.pl: ${MTEVAL[$name]} sacreBLEU: $score"
+
+        let i++
+    done
+fi
+
+#############
+# Mecab-ko tests
+#############
+if [[ -z $SKIP_MECAB_KO ]]; then
+  echo "-----------------------"
+  echo "Testing Mecab-ko tokenizer"
+  echo "-----------------------"
+    pair="en-ko"
+    source=$(echo $pair | cut -d- -f1)
+    target=$(echo $pair | cut -d- -f2)
+    for txt in en-ko-translation-example-master/*.hyp.$target; do
         name=$(basename $txt .hyp.$target)
 
         if [[ ! -z $limit_test && $limit_test != $name ]]; then continue; fi


### PR DESCRIPTION
Korean tokenizer is required to evaluate Korean

[Mecab-ko](https://bitbucket.org/eunjeon/mecab-ko) is a slightly modified version of [Mecab](https://taku910.github.io/mecab) due to the difference between Korean and Japanese, and has been widely used by Korean language researchers even among various tokenizers because it has the advantage of high speed.

To take full advantage of the fact that the code is not very different, I made the [pymecab-ko](https://github.com/NoUnique/pymecab-ko) by modifying [mecab-python3](https://github.com/SamuraiT/mecab-python3) used by sacrebleu

I wrote the code in a style as close as possible to the previously added `ja-mecab` option.
The newly added tests were tested on Ubuntu20.04.