### PR TITLE
Allow None references in args check

### DIFF
--- a/sacrebleu/metrics/base.py
+++ b/sacrebleu/metrics/base.py
@@ -220,7 +220,7 @@ class Metric(metaclass=ABCMeta):
             err_msg = 'The argument `hyp` should be a string.'
         elif isinstance(refs, str) or not isinstance(refs, Sequence):
             err_msg = 'The argument `refs` should be a sequence of strings.'
-        elif not isinstance(refs[0], str):
+        elif not isinstance(refs[0], str) and refs[0] is not None:
             err_msg = 'Each element of `refs` should be a string.'
 
         if err_msg:
@@ -251,7 +251,7 @@ class Metric(metaclass=ABCMeta):
                 err_msg = "`refs` should be a sequence of sequence of strings."
             elif not isinstance(refs[0], Sequence):
                 err_msg = "Each element of `refs` should be a sequence of strings."
-            elif not isinstance(refs[0][0], str):
+            elif not isinstance(refs[0][0], str) and refs[0][0] is not None:
                 err_msg = "`refs` should be a sequence of sequence of strings."
 
         if err_msg:


### PR DESCRIPTION
This PR updates the arguments check to support variable references.

Sacrebleu allows for references to be replaced with either None or the empty string. However, the arguments check did not allow None as the first reference. For example, the code example in the Readme (https://github.com/mjpost/sacrebleu#variable-number-of-references) failed if None was used instead of the empty string.