### PR TITLE
Multiref bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+- 2.2.1 (2022-09-13)
+  Bugfix: Standard usage was returning (and using) each reference twice.
+
 - 2.2.0 (2022-07-25)
   Features:
   - Added WMT21 datasets (thanks to @BrighXiaoHan)

--- a/sacrebleu/__init__.py
+++ b/sacrebleu/__init__.py
@@ -14,7 +14,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 __description__ = 'Hassle-free computation of shareable, comparable, and reproducible BLEU, chrF, and TER scores'
 
 

--- a/sacrebleu/dataset/wmt_xml.py
+++ b/sacrebleu/dataset/wmt_xml.py
@@ -95,11 +95,6 @@ class WMTXMLDataset(Dataset):
                 orig_langs.append(origlang)
                 src_sent_count += 1
 
-        # For backward compatibility, if "ref" is not in the fields,
-        # add reference sentences from the first translator as "ref" field
-        if "ref" not in refs:
-            refs["ref"] = refs[min(refs.keys())]
-
         return {"src": src, **refs, "docid": docids, "origlang": orig_langs,}
 
     def process_to_text(self, langpair=None):


### PR DESCRIPTION
`sacrebleu -t wmt21 -l en-de` scores with "ref:A" and the backwards compatible "ref" field, which are identical.

This fixes a bug introduced here https://github.com/mjpost/sacrebleu/pull/187/commits/70a74305c3698ce4e8e97f5d2d080846757b5cc6.