### PR TITLE
Add support to print multi system results as JSON

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         exclude:
           - os: windows-latest
             python-version: '3.6'   # test fails due to UTF8 stuff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-- 2.2.2 (2022-10-XX)
+- 2.3.0 (2022-10-XX)
   Features:
   - (#203) Added `-tok flores101` and `-tok flores200`, a.k.a. `spbleu`.
     These are multilingual tokenizations that make use of the
@@ -11,9 +11,6 @@
   - (#213) Added JSON formatting for multi-system output (thanks to Manikanta Inugurthi @me-manikanta)
   - (#211) You can now list all test sets for a language pair with `--list SRC-TRG`.
     Thanks to Jaume Zaragoza (@ZJaume) for adding this feature.
-
-  Changes:
-  - Removed testing support for Python 3.6 (end-of-lifed: https://endoflife.date/python).
 
 - 2.2.1 (2022-09-13)
   Bugfix: Standard usage was returning (and using) each reference twice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-- 2.2.2 (2022-09-29)
+- 2.2.2 (2022-10-XX)
   Features:
   - Added `-tok flores101` and `-tok flores200`, a.k.a. `spbleu`.
     These are multilingual tokenizations that make use of the
@@ -8,6 +8,7 @@
     following papers:
     * Flores-101: https://arxiv.org/abs/2106.03193
     * Flores-200: https://arxiv.org/abs/2207.04672
+  - Added JSON formatting for multi-system output (thanks to Manikanta Inugurthi @me-manikanta)
 
 - 2.2.1 (2022-09-13)
   Bugfix: Standard usage was returning (and using) each reference twice.

--- a/sacrebleu/__init__.py
+++ b/sacrebleu/__init__.py
@@ -14,7 +14,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.2.2'
+__version__ = '2.3.0'
 __description__ = 'Hassle-free computation of shareable, comparable, and reproducible BLEU, chrF, and TER scores'
 
 

--- a/sacrebleu/utils.py
+++ b/sacrebleu/utils.py
@@ -96,7 +96,7 @@ def print_results_table(results: dict, signatures: dict, args: Namespace):
         dict_keys = list(results.keys())
         for i in range(len(results['System'])):
             value = {}
-            value['System'] = results['System'][i]
+            value['system'] = results['System'][i]
             # parse metrics
             for j in range(1, len(dict_keys)):
                 if isinstance(results[dict_keys[j]][i], str):

--- a/sacrebleu/utils.py
+++ b/sacrebleu/utils.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import sys
@@ -90,9 +91,26 @@ def _format_score_lines(scores: dict,
 def print_results_table(results: dict, signatures: dict, args: Namespace):
     """Prints out a nicely formatted table for multi-system evaluation mode."""
 
+    if args.format == 'json':
+        proper_json = []
+        dict_keys = list(results.keys())
+        for i in range(len(results['System'])):
+            value = {}
+            value['System'] = results['System'][i]
+            # parse metrics
+            for j in range(1, len(dict_keys)):
+                if isinstance(results[dict_keys[j]][i], str):
+                    value[dict_keys[j]] = results[dict_keys[j]][i]
+                else:
+                    # Values inside object as dict
+                    value[dict_keys[j]] = results[dict_keys[j]][i].__dict__
+            proper_json.append(value)
+
+        print(json.dumps(proper_json, indent=4))
+        return
+
     tablefmt = args.format
-    if tablefmt in ('text', 'json'):
-        # Fallback to simple table if json is given
+    if tablefmt in ('text'):
         tablefmt = 'fancy_grid'
     elif tablefmt == 'latex':
         # Use booktabs


### PR DESCRIPTION
Issue #207

Added logic to convert the multi-system output to a dictionary and print the dictionary as JSON

## Verified the changes for the following:
### BLEU and CHRF for Multiple Systems
```sh
python3 sacrebleu/sacrebleu.py --input data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.KIT.4951.de-en data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.LIUM-NMT.4733.de-en --language-pair hi-en  -lc  --encoding utf-8-sig data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.C-3MA.4958.de-en -m bleu chrf  -sh --format json 
```
**Output:**
```json
[
    {
        "System": "data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.KIT.4951.de-en",
        "BLEU": "55.1",
        "chrF2": "73.8"
    },
    {
        "System": "data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.LIUM-NMT.4733.de-en",
        "BLEU": "52.2",
        "chrF2": "72.1"
    }
]
```
### Paired test using bootstrap resampling
```sh
python3 sacrebleu/sacrebleu.py --input data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.KIT.4951.de-en data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.LIUM-NMT.4733.de-en --language-pair hi-en  -lc  --encoding utf-8-sig data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.C-3MA.4958.de-en -m bleu chrf  -sh --format json --paired-bs
```
**Output:**
```json
[
    {
        "System": "Baseline: data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.KIT.4951.de-en",
        "BLEU": {
            "score": 55.05078088066641,
            "p_value": null,
            "mean": 55.04298847040095,
            "ci": 0.7779333388823026
        },
        "chrF2": {
            "score": 73.81214722094455,
            "p_value": null,
            "mean": 73.79934401771284,
            "ci": 0.48946591806097217
        }
    },
    {
        "System": "data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.LIUM-NMT.4733.de-en",
        "BLEU": {
            "score": 52.18305014543905,
            "p_value": 0.000999000999000999,
            "mean": 52.18573885163444,
            "ci": 0.7636661706325505
        },
        "chrF2": {
            "score": 72.10939066073507,
            "p_value": 0.000999000999000999,
            "mean": 72.10817046815828,
            "ci": 0.5031330617618934
        }
    }
]
```

### Paired test using approximate randomization 
```sh
python3 sacrebleu/sacrebleu.py --input data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.KIT.4951.de-en data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.LIUM-NMT.4733.de-en --language-pair hi-en  -lc  --encoding utf-8-sig data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.C-3MA.4958.de-en -m bleu chrf  -sh --format json --paired-ar
```
**Output:**
```json
[
    {
        "System": "Baseline: data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.KIT.4951.de-en",
        "BLEU": {
            "score": 55.05078088066641,
            "p_value": null,
            "mean": null,
            "ci": null
        },
        "chrF2": {
            "score": 73.81214722094455,
            "p_value": null,
            "mean": null,
            "ci": null
        }
    },
    {
        "System": "data/wmt17-submitted-data/txt/system-outputs/newstest2017/de-en/newstest2017.LIUM-NMT.4733.de-en",
        "BLEU": {
            "score": 52.18305014543905,
            "p_value": 9.999000099990002e-05,
            "mean": null,
            "ci": null
        },
        "chrF2": {
            "score": 72.10939066073507,
            "p_value": 9.999000099990002e-05,
            "mean": null,
            "ci": null
        }
    }
]
```

### Other tests
Similar results are generated when using `--paired-bs-n` and `--paired-ar-n`



