### PR TITLE
Update tokenizer_spm.py to issue warning message only when 'spm' is used

### DIFF
--- a/sacrebleu/tokenizers/tokenizer_spm.py
+++ b/sacrebleu/tokenizers/tokenizer_spm.py
@@ -34,7 +34,8 @@ class TokenizerSPM(BaseTokenizer):
     def __init__(self, key="spm"):
         self.name = SPM_MODELS[key]["signature"]
 
-        sacrelogger.warn("Tokenizer 'spm' has been changed to 'flores101', and may be removed in the future.")
+        if key == 'spm':
+            sacrelogger.warn("Tokenizer 'spm' has been changed to 'flores101', and may be removed in the future.")
 
         try:
             import sentencepiece as spm

--- a/sacrebleu/tokenizers/tokenizer_spm.py
+++ b/sacrebleu/tokenizers/tokenizer_spm.py
@@ -34,7 +34,7 @@ class TokenizerSPM(BaseTokenizer):
     def __init__(self, key="spm"):
         self.name = SPM_MODELS[key]["signature"]
 
-        if key == 'spm':
+        if key == "spm":
             sacrelogger.warn("Tokenizer 'spm' has been changed to 'flores101', and may be removed in the future.")
 
         try:


### PR DESCRIPTION
Fixes issue 219  by printing the warning only when 'spm' is used.
https://github.com/mjpost/sacrebleu/issues/219