### PR TITLE
Add optimization for compute_bleu precision initialization

### DIFF
--- a/sacrebleu/metrics/bleu.py
+++ b/sacrebleu/metrics/bleu.py
@@ -251,7 +251,7 @@ class BLEU(Metric):
             bp = 1.0
 
         # n-gram precisions
-        precisions = [0.0 for x in range(max_ngram_order)]
+        precisions = [0.0] * max_ngram_order
 
         # Early stop if there are no matches (#141)
         if not any(correct):

--- a/sacrebleu/metrics/bleu.py
+++ b/sacrebleu/metrics/bleu.py
@@ -245,10 +245,9 @@ class BLEU(Metric):
             smooth_value = BLEU.SMOOTH_DEFAULTS[smooth_method]
 
         # Compute brevity penalty
+        bp = 1.0
         if sys_len < ref_len:
-            bp = math.exp(1 - ref_len / sys_len) if sys_len > 0 else 0.0
-        else:
-            bp = 1.0
+            bp = math.exp(1 - ref_len / sys_len) if sys_len > 0 else 0.0            
 
         # n-gram precisions
         precisions = [0.0] * max_ngram_order


### PR DESCRIPTION
Description: Added a one-line optimization for initialization of the `precissions` list in `def compute_bleu` function.

Motivation: I have to do a total of 7 billion computations so I was looking at possibilities for optimizing the computation routine. I find that this change is about x4 faster for the operation, consisting of about 12% of total improvement for the function. Added a screenshots of my timings. See the diff between `precissions_old` and `precissions_optim`. Numbers are averaged over 10k computations.

![image](https://github.com/mjpost/sacrebleu/assets/40242518/dac408c5-66c3-487a-82c6-40aa0f55805a)

P.s. this change is also reflected in this StackOverflow post https://stackoverflow.com/questions/20816600/best-and-or-fastest-way-to-create-lists-in-python