### PR TITLE
Fix CI Errors

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -18,42 +18,40 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: windows-latest
-            python-version: '3.6'   # test fails due to UTF8 stuff
-          - os: ubuntu-latest
-            python-version: '3.6'   # not available in Ubuntu 22.04+
-        include:
-          - os: ubuntu-20.04
-            python-version: '3.6'   # test Python 3.6 on older Ubuntu instead
+            python-version: '3.12'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - if: matrix.os == 'macos-latest'
+      - if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14' }}
         name: Install Mac OS requirements
         run: brew install bash
       - if: matrix.os == 'windows-latest'
         name: Install Windows requirements
         run: choco install wget unzip
-      - name: Install python dependencies
+      - if: ${{ matrix.os != 'macos-14' && matrix.python-version != '3.12' }}
+        name: Install python dependencies
+        run: pip install ".[dev,ja,ko]"
+      - # mecab-ko doesn't support Apple Silicon or Python 3.12 yet.
+        if: ${{ matrix.os == 'macos-14' || matrix.python-version == '3.12' }}
+        name: Install Python dependencies on Apple Silicon or Python 3.12
         run: |
-          python3 -m pip install --upgrade pip
-          pip3 install .[dev]
-          pip3 install .[ja]
-          pip3 install .[ko]
+          pip install ".[dev,ja]"
+          echo "SKIP_MECAB_KO=true" >> $GITHUB_ENV
       - name: Lint with Mypy
         run: mypy sacrebleu scripts test
       - name: Lint with Ruff
         uses: chartboost/ruff-action@v1
       - name: Python pytest test suite
-        run: python3 -m pytest
+        run: python -m pytest
       - name: CLI bash test suite
         shell: bash
         run: ./test.sh
       - name: Build
-        run: python3 setup.py sdist bdist_wheel
+        run: python setup.py sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ sacrebleu -i output.detok.txt -t wmt17 -l en-de | jq -r .score
 
 # Installation
 
-Install the official Python module from PyPI (**Python>=3.6 only**):
+Install the official Python module from PyPI (**Python>=3.8 only**):
 
     pip install sacrebleu
 

--- a/setup.py
+++ b/setup.py
@@ -102,8 +102,8 @@ setup(
     author_email='post@cs.jhu.edu',
     maintainer_email='post@cs.jhu.edu',
     license='Apache License 2.0',
-    # We don't support Python < 3.6 anymore
-    python_requires='>=3.6',
+    # We don't support Python < 3.8 anymore
+    python_requires='>=3.8',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are
@@ -154,8 +154,8 @@ setup(
     # dependencies). You can install these using the following syntax,
     # for example:
     # $ pip install -e .[dev,test]
-    extras_require={'dev': ['wheel', 'pytest', 'mypy', 'types-tabulate', 'lxml-stubs'],
-                    'ja': ['mecab-python3>=1.0.5,<=1.0.6', 'ipadic>=1.0,<2.0'],
+    extras_require={'dev': ['wheel', 'pytest', 'mypy', 'types-tabulate', 'lxml-stubs', 'setuptools'],
+                    'ja': ['mecab-python3>=1.0.9,<2.0.0', 'ipadic>=1.0,<2.0'],
                     'ko': ['mecab-ko>=1.0.0,<=1.0.1', 'mecab-ko-dic>=1.0,<2.0']},
 
     # To provide executable scripts, use entry points in preference to the


### PR DESCRIPTION
This PR addresses recent CI errors. It includes the following changes:

- Removed support for Python 3.6 and 3.7 since they are deprecated.
- Tests now run on both Intel Mac (macos-13) and Apple Silicon Mac (macos-14).
- Updated `mecab-python3` to support Apple Silicon and Python 3.12.
- Skipped tests with `mecab-ko` on Apple Silicon or Python 3.12 because it doesn’t support them yet. (https://github.com/NoUnique/pymecab-ko/issues/2, https://github.com/NoUnique/pymecab-ko/issues/8)