### PR TITLE
Fix CI error

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[build]
+        pip install build
     - name: Build sdist and wheel
       run: |
         python -m build


### PR DESCRIPTION
This PR fixes the CI error https://github.com/mjpost/sacrebleu/actions/runs/10151812795.

The pip command now matches the one used in the other CI script:

https://github.com/mjpost/sacrebleu/blob/5af5a3afd859f5825812feb14084a30b34960ee3/.github/workflows/check-build.yml#L56-L59