### PR TITLE
pyproject.toml follows PEP639 and allows mecab-ko<2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ maintainers = [{ name = "Matt Post", email = "post@cs.jhu.edu" }]
 description = "Hassle-free computation of shareable, comparable, and reproducible BLEU, chrF, and TER scores"
 readme = "README.md"
 license = "Apache-2.0"
-license-files = ["LICENSE.txt"]
 classifiers = [
     # How mature is this project? Common values are
     #   3 - Alpha


### PR DESCRIPTION
follow https://peps.python.org/pep-0639/
see #284