### PR TITLE
Drop Python 3.8, add Python 3.13, use PEP 639 SPDX license format

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -19,10 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, macos-14, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          - os: windows-latest
-            python-version: '3.12'
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python-version }}
@@ -35,15 +32,8 @@ jobs:
       - if: matrix.os == 'windows-latest'
         name: Install Windows requirements
         run: choco install wget unzip
-      - if: ${{ matrix.os != 'macos-14' && matrix.python-version != '3.12' }}
-        name: Install python dependencies
+      - name: Install python dependencies
         run: pip install ".[dev,ja,ko]"
-      - # mecab-ko doesn't support Apple Silicon or Python 3.12 yet.
-        if: ${{ matrix.os == 'macos-14' || matrix.python-version == '3.12' }}
-        name: Install Python dependencies on Apple Silicon or Python 3.12
-        run: |
-          pip install ".[dev,ja]"
-          echo "SKIP_MECAB_KO=true" >> $GITHUB_ENV
       - name: Lint with Mypy
         run: mypy sacrebleu scripts test
       - name: Lint with Ruff

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ sacrebleu -i output.detok.txt -t wmt17 -l en-de | jq -r .score
 
 # Installation
 
-Install the official Python module from PyPI (**Python>=3.8 only**):
+Install the official Python module from PyPI (**Python>=3.9 only**):
 
     pip install sacrebleu
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=77", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -37,7 +37,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 keywords = [
     "machine translation",
@@ -59,7 +59,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["wheel", "pytest", "mypy", "types-tabulate", "lxml-stubs", "setuptools"]
 ja = ["mecab-python3>=1.0.9,<2.0.0", "ipadic>=1.0,<2.0"]
-ko = ["mecab-ko>=1.0.0,<2.0.0", "mecab-ko-dic>=1.0,<2.0"]
+ko = ["mecab-ko>=1.0.2,<2.0.0", "mecab-ko-dic>=1.0,<2.0"]
 
 [project.scripts]
 sacrebleu = "sacrebleu.sacrebleu:main"


### PR DESCRIPTION
* drop Python 3.8 support and update Python version requirement to >=3.9
* add Python 3.13 to CI tests, remove mecab-ko exceptions in the tests
* use PEP 639 SPDX license format in pyproject.toml

The adoption of PEP 639 and drop of Python 3.8 (that reached EoL in 2024) was motivated by the following warning by setuptools: [By 2026-Feb-18, you need to update your project and remove deprecated calls](https://github.com/pypa/setuptools/issues/4903).