### PR TITLE
Fix PyPI version badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sacreBLEU
 
-[![PyPI version](https://img.shields.io/pypi/v/sacrebleu)](https://img.shields.io/pypi/v/sacrebleu)
+[![PyPI version](https://img.shields.io/pypi/v/sacrebleu)](https://pypi.org/project/sacrebleu/)
 [![Python version](https://img.shields.io/pypi/pyversions/sacrebleu)](https://img.shields.io/pypi/pyversions/sacrebleu)
 [![GitHub issues](https://img.shields.io/github/issues/mjpost/sacreBLEU.svg)](https://github.com/mjpost/sacrebleu/issues)
 


### PR DESCRIPTION
Updated PyPI version badge link to point directly to https://pypi.org/project/sacrebleu/