### PR TITLE
Fix wmt21/systems example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ sacrebleu -t wmt21/systems -l zh-en --echo NiuTrans
 This provides a convenient way to score:
 
 ```bash
-$ sacrebleu -t wmt21/system -l zh-en --echo NiuTrans | sacrebleu -t wmt21/systems -l zh-en
+$ sacrebleu -t wmt21/systems -l zh-en --echo NiuTrans | sacrebleu -t wmt21/systems -l zh-en
 ```
 
 You can see a list of the available outputs by passing an invalid value to `--echo`.


### PR DESCRIPTION
The second example in the README uses wmt21/system (singular), but the correct test set name is wmt21/systems (plural).

I verified that the corrected command works locally.