### PR TITLE
feat: add Word Error Rate (WER) metric

### DIFF
--- a/sacrebleu/__init__.py
+++ b/sacrebleu/__init__.py
@@ -22,13 +22,15 @@ from .compat import (
     corpus_bleu,
     corpus_chrf,
     corpus_ter,
+    corpus_wer,
     raw_corpus_bleu,
     sentence_bleu,
     sentence_chrf,
     sentence_ter,
+    sentence_wer,
 )
 from .dataset import DATASETS
-from .metrics import BLEU, CHRF, TER
+from .metrics import BLEU, CHRF, TER, WER
 from .metrics.helpers import extract_char_ngrams, extract_word_ngrams
 from .utils import (
     SACREBLEU_DIR,
@@ -55,6 +57,7 @@ __all__ = [
     "BLEU",
     "CHRF",
     "TER",
+    "WER",
     "corpus_bleu",
     "raw_corpus_bleu",
     "sentence_bleu",
@@ -62,5 +65,7 @@ __all__ = [
     "sentence_chrf",
     "corpus_ter",
     "sentence_ter",
+    "corpus_wer",
+    "sentence_wer",
     "__version__",
 ]

--- a/sacrebleu/compat.py
+++ b/sacrebleu/compat.py
@@ -1,6 +1,6 @@
 from typing import Sequence, Optional
 
-from .metrics import BLEU, CHRF, TER, BLEUScore, CHRFScore, TERScore
+from .metrics import BLEU, CHRF, TER, WER, BLEUScore, CHRFScore, TERScore, WERScore
 
 
 ######################################################################
@@ -202,4 +202,35 @@ def sentence_ter(hypothesis: str,
         no_punct=no_punct,
         asian_support=asian_support,
         case_sensitive=case_sensitive)
+    return metric.sentence_score(hypothesis, references)
+
+
+def corpus_wer(hypotheses: Sequence[str],
+               references: Sequence[Sequence[str]],
+               case_sensitive: bool = False) -> WERScore:
+    """
+    Computes WER for a corpus against a single (or multiple) reference(s).
+
+    :param hypotheses: A sequence of hypothesis strings.
+    :param references: A sequence of reference documents with document being
+        defined as a sequence of reference strings.
+    :param case_sensitive: Enables case-sensitivity.
+    :return: A `WERScore` object.
+    """
+    metric = WER(case_sensitive=case_sensitive)
+    return metric.corpus_score(hypotheses, references)
+
+
+def sentence_wer(hypothesis: str,
+                 references: Sequence[str],
+                 case_sensitive: bool = False) -> WERScore:
+    """
+    Computes WER for a single hypothesis against a single (or multiple) reference(s).
+
+    :param hypothesis: A single hypothesis string.
+    :param references: A sequence of reference strings.
+    :param case_sensitive: Enable case-sensitivity.
+    :return: A `WERScore` object.
+    """
+    metric = WER(case_sensitive=case_sensitive)
     return metric.sentence_score(hypothesis, references)

--- a/sacrebleu/metrics/__init__.py
+++ b/sacrebleu/metrics/__init__.py
@@ -3,9 +3,11 @@
 from .bleu import BLEU, BLEUScore   # noqa: F401
 from .chrf import CHRF, CHRFScore   # noqa: F401
 from .ter import TER, TERScore      # noqa: F401
+from .wer import WER, WERScore      # noqa: F401
 
 METRICS = {
     'BLEU': BLEU,
     'CHRF': CHRF,
     'TER': TER,
+    'WER': WER,
 }

--- a/sacrebleu/metrics/lib_wer.py
+++ b/sacrebleu/metrics/lib_wer.py
@@ -1,0 +1,52 @@
+"""This module implements the word-level edit distance used by the WER metric."""
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Tuple
+
+
+def word_error_rate_stats(words_hyp: List[str], words_ref: List[str]) -> Tuple[int, int]:
+    """Computes the word-level edit distance (Levenshtein distance, i.e. the
+    minimum number of word substitutions, insertions and deletions) between a
+    hypothesis and a reference, as used by Word Error Rate (WER).
+
+    Unlike TER, WER does not consider block "shifts" as a single edit.
+
+    :param words_hyp: Tokenized hypothesis.
+    :param words_ref: Tokenized reference.
+    :return: tuple (number of edits, reference length)
+    """
+    n_words_ref = len(words_ref)
+    n_words_hyp = len(words_hyp)
+
+    if n_words_ref == 0:
+        # Special treatment of empty references, consistent with TER.
+        return n_words_hyp, 0
+
+    # Rolling two-row dynamic programming; O(n_words_hyp * n_words_ref) time,
+    # O(n_words_ref) space.
+    previous_row = list(range(n_words_ref + 1))
+    for i, word_hyp in enumerate(words_hyp, start=1):
+        current_row = [i] + [0] * n_words_ref
+        for j, word_ref in enumerate(words_ref, start=1):
+            if word_hyp == word_ref:
+                current_row[j] = previous_row[j - 1]
+            else:
+                current_row[j] = 1 + min(
+                    previous_row[j - 1],  # substitution
+                    previous_row[j],      # deletion
+                    current_row[j - 1],   # insertion
+                )
+        previous_row = current_row
+
+    return previous_row[n_words_ref], n_words_ref

--- a/sacrebleu/metrics/lib_wer.py
+++ b/sacrebleu/metrics/lib_wer.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple
 
-
-def word_error_rate_stats(words_hyp: List[str], words_ref: List[str]) -> Tuple[int, int]:
+def word_error_rate_stats(words_hyp: list[str], words_ref: list[str]) -> tuple[int, int]:
     """Computes the word-level edit distance (Levenshtein distance, i.e. the
     minimum number of word substitutions, insertions and deletions) between a
     hypothesis and a reference, as used by Word Error Rate (WER).

--- a/sacrebleu/metrics/wer.py
+++ b/sacrebleu/metrics/wer.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 
-from typing import List, Dict, Sequence, Optional, Any
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
 
 from ..utils import sum_of_lists
-from .base import Score, Signature, Metric
+from .base import Metric, Score, Signature
 from .lib_wer import word_error_rate_stats
 
 
@@ -71,7 +74,7 @@ class WER(Metric):
     _SIGNATURE_TYPE = WERSignature
 
     def __init__(self, case_sensitive: bool = False,
-                 references: Optional[Sequence[Sequence[str]]] = None):
+                 references: Sequence[Sequence[str]] | None = None):
         """`WER` initializer."""
         super().__init__()
 
@@ -89,7 +92,7 @@ class WER(Metric):
         sent = sent.rstrip()
         return sent if self.case_sensitive else sent.lower()
 
-    def _compute_score_from_stats(self, stats: List[float]) -> WERScore:
+    def _compute_score_from_stats(self, stats: list[float]) -> WERScore:
         """Computes the final score from already aggregated statistics.
 
         :param stats: A list or numpy array of segment-level statistics.
@@ -106,7 +109,7 @@ class WER(Metric):
 
         return WERScore(100 * score, total_edits, sum_ref_lengths)
 
-    def _aggregate_and_compute(self, stats: List[List[float]]) -> WERScore:
+    def _aggregate_and_compute(self, stats: list[list[float]]) -> WERScore:
         """Computes the final WER score given the pre-computed corpus statistics.
 
         :param stats: A list of segment-level statistics
@@ -115,7 +118,7 @@ class WER(Metric):
         return self._compute_score_from_stats(sum_of_lists(stats))
 
     def _compute_segment_statistics(
-            self, hypothesis: str, ref_kwargs: Dict) -> List[float]:
+            self, hypothesis: str, ref_kwargs: dict) -> list[float]:
         """Given a (pre-processed) hypothesis sentence and already computed
         reference words, returns the segment statistics required to compute
         the full WER score.
@@ -136,13 +139,12 @@ class WER(Metric):
         for words_ref in ref_words:
             num_edits, ref_len = word_error_rate_stats(words_hyp, words_ref)
             ref_lengths += ref_len
-            if num_edits < best_num_edits:
-                best_num_edits = num_edits
+            best_num_edits = min(best_num_edits, num_edits)
 
         avg_ref_len = ref_lengths / len(ref_words)
         return [best_num_edits, avg_ref_len]
 
-    def _extract_reference_info(self, refs: Sequence[str]) -> Dict[str, Any]:
+    def _extract_reference_info(self, refs: Sequence[str]) -> dict[str, Any]:
         """Given a list of reference segments, applies pre-processing and
         returns list of tokens for each reference.
 

--- a/sacrebleu/metrics/wer.py
+++ b/sacrebleu/metrics/wer.py
@@ -1,0 +1,158 @@
+"""The implementation of the Word Error Rate (WER) metric."""
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import List, Dict, Sequence, Optional, Any
+
+from ..utils import sum_of_lists
+from .base import Score, Signature, Metric
+from .lib_wer import word_error_rate_stats
+
+
+class WERSignature(Signature):
+    """A convenience class to represent the reproducibility signature for WER.
+
+    :param args: key-value dictionary passed from the actual metric instance.
+    """
+    def __init__(self, args: dict):
+        """`WERSignature` initializer."""
+        super().__init__(args)
+        self._abbr.update({
+            'case': 'c',
+        })
+
+        self.info.update({
+            'case': 'mixed' if args['case_sensitive'] else 'lc',
+        })
+
+
+class WERScore(Score):
+    """A convenience class to represent WER scores.
+
+    :param score: The WER score.
+    :param num_edits: The cumulative number of edits.
+    :param ref_length: The cumulative average reference length.
+    """
+    def __init__(self, score: float, num_edits: float, ref_length: float):
+        """`WERScore` initializer."""
+        super().__init__('WER', score)
+        self.num_edits = int(num_edits)
+        self.ref_length = ref_length
+
+
+class WER(Metric):
+    """Word error rate (WER). The word-level edit distance between a
+    hypothesis and the closest-matching reference, normalized by the
+    reference length, expressed as a percentage.
+
+    Unlike TER, WER does not treat contiguous word-block reorderings
+    ("shifts") as a single edit -- it is plain word-level Levenshtein
+    distance, which keeps the implementation simple and dependency-free
+    at the cost of being slower than a C-backed edit-distance library for
+    very long sequences.
+
+    :param case_sensitive: If `True`, does not lowercase sentences.
+    :param references: A sequence of reference documents with document being
+        defined as a sequence of reference strings. If given, the reference info
+        will be pre-computed and cached for faster re-computation across many systems.
+    """
+
+    _SIGNATURE_TYPE = WERSignature
+
+    def __init__(self, case_sensitive: bool = False,
+                 references: Optional[Sequence[Sequence[str]]] = None):
+        """`WER` initializer."""
+        super().__init__()
+
+        self.case_sensitive = case_sensitive
+
+        if references is not None:
+            self._ref_cache = self._cache_references(references)
+
+    def _preprocess_segment(self, sent: str) -> str:
+        """Given a sentence, apply case-folding if enabled.
+
+        :param sent: The input sentence string.
+        :return: The pre-processed output string.
+        """
+        sent = sent.rstrip()
+        return sent if self.case_sensitive else sent.lower()
+
+    def _compute_score_from_stats(self, stats: List[float]) -> WERScore:
+        """Computes the final score from already aggregated statistics.
+
+        :param stats: A list or numpy array of segment-level statistics.
+        :return: A `WERScore` object.
+        """
+        total_edits, sum_ref_lengths = stats[0], stats[1]
+
+        if sum_ref_lengths > 0:
+            score = total_edits / sum_ref_lengths
+        elif total_edits > 0:
+            score = 1.0  # empty reference(s) and non-empty hypothesis
+        else:
+            score = 0.0  # both reference(s) and hypothesis are empty
+
+        return WERScore(100 * score, total_edits, sum_ref_lengths)
+
+    def _aggregate_and_compute(self, stats: List[List[float]]) -> WERScore:
+        """Computes the final WER score given the pre-computed corpus statistics.
+
+        :param stats: A list of segment-level statistics
+        :return: A `WERScore` instance.
+        """
+        return self._compute_score_from_stats(sum_of_lists(stats))
+
+    def _compute_segment_statistics(
+            self, hypothesis: str, ref_kwargs: Dict) -> List[float]:
+        """Given a (pre-processed) hypothesis sentence and already computed
+        reference words, returns the segment statistics required to compute
+        the full WER score.
+
+        :param hypothesis: Hypothesis sentence.
+        :param ref_kwargs: A dictionary with `ref_words` key which is a list
+        where each sublist contains reference words.
+        :return: A two-element list that contains the 'minimum number of edits'
+        and 'the average reference length'.
+        """
+        ref_lengths = 0
+        best_num_edits = int(1e16)
+
+        words_hyp = hypothesis.split()
+
+        # Iterate the references
+        ref_words = ref_kwargs['ref_words']
+        for words_ref in ref_words:
+            num_edits, ref_len = word_error_rate_stats(words_hyp, words_ref)
+            ref_lengths += ref_len
+            if num_edits < best_num_edits:
+                best_num_edits = num_edits
+
+        avg_ref_len = ref_lengths / len(ref_words)
+        return [best_num_edits, avg_ref_len]
+
+    def _extract_reference_info(self, refs: Sequence[str]) -> Dict[str, Any]:
+        """Given a list of reference segments, applies pre-processing and
+        returns list of tokens for each reference.
+
+        :param refs: A sequence of strings.
+        :return: A dictionary that will be passed to `_compute_segment_statistics()`
+        through keyword arguments.
+        """
+        ref_words = []
+
+        for ref in refs:
+            ref_words.append(self._preprocess_segment(ref).split())
+
+        return {'ref_words': ref_words}

--- a/test/test_wer.py
+++ b/test/test_wer.py
@@ -1,0 +1,33 @@
+import pytest
+import sacrebleu
+
+EPSILON = 1e-3
+
+test_cases = [
+    (['aaaa bbbb cccc dddd'], ['aaaa bbbb cccc dddd'], 0),  # perfect match
+    (['dddd eeee ffff'], ['aaaa bbbb cccc'], 1),  # no overlap, same length
+    ([''], ['a'], 1),  # corner case, empty hypothesis
+    (['a'], [''], 1),  # corner case, empty reference
+    ([''], [''], 0),  # corner case, both reference and hypothesis empty, we define it as 0.0
+    (['the cat sat on the mat'], ['the cat sat on a mat'], 1 / 6),  # single word substitution
+    (['a b c d'], ['a b d'], 1 / 3),  # single word insertion in the hypothesis
+]
+
+
+@pytest.mark.parametrize("hypotheses, references, expected_score", test_cases)
+def test_wer(hypotheses, references, expected_score):
+    metric = sacrebleu.metrics.WER()
+    score = metric.corpus_score(hypotheses, [references]).score
+    assert abs(score - 100 * expected_score) < EPSILON
+
+
+def test_wer_case_sensitive():
+    metric = sacrebleu.metrics.WER(case_sensitive=True)
+    score = metric.corpus_score(['The cat sat.'], [['the cat sat.']]).score
+    assert abs(score - 100 * (1 / 3)) < EPSILON
+
+
+def test_wer_case_insensitive_by_default():
+    metric = sacrebleu.metrics.WER()
+    score = metric.corpus_score(['The cat sat.'], [['the cat sat.']]).score
+    assert score == 0

--- a/test/test_wer.py
+++ b/test/test_wer.py
@@ -1,4 +1,5 @@
 import pytest
+
 import sacrebleu
 
 EPSILON = 1e-3


### PR DESCRIPTION
Closes #199

## What
Adds a `WER` metric alongside `BLEU`/`CHRF`/`TER`, following the exact same `Metric`/`Score`/`Signature` structure as `TER` (`_preprocess_segment`, `_extract_reference_info`, `_compute_segment_statistics`, `_compute_score_from_stats`, `_aggregate_and_compute`).

Uses a plain word-level Levenshtein distance (`lib_wer.py`) rather than TER's shift-aware beam search — WER has no concept of block "shifts" as a single edit (that's specifically a TER/MT-evaluation feature), so it doesn't need `lib_ter.py`'s complexity.

Registered in `METRICS`, which also wires `wer` into the CLI's `--metrics` choices automatically, and exposed via `corpus_wer()`/`sentence_wer()` compat functions mirroring `corpus_ter()`/`sentence_ter()`.

## On the dependency question raised in the issue thread
Saw the back-and-forth about whether to use the `editdistance` C-backed package for speed. Went with pure Python / no new dependency, per @martinpopel's original comment that "WER is simple ... it does not need any extra dependencies" — and it matches TER's own existing precedent of being dependency-free. Totally open to switching to `editdistance` if the speed concern outweighs that, happy to adjust.

## Tests
Added `test/test_wer.py` mirroring `test/test_ter.py`'s style: perfect match, no-overlap, the three TER corner cases (empty hyp/ref/both), plus two WER-specific cases (single substitution, single insertion) and two case-sensitivity tests.

## Validation
Ran `test/test_wer.py` (9/9 passing) and `test/test_ter.py` (7/7 still passing, confirming no regression from the registry changes in `metrics/__init__.py`/`compat.py`/`sacrebleu/__init__.py`). Confirmed via `--help` that `wer` appears correctly in the CLI's `--metrics` choices.